### PR TITLE
Fix line break in rhoas-cli guide

### DIFF
--- a/rhoas-cli/README.adoc
+++ b/rhoas-cli/README.adoc
@@ -7,11 +7,13 @@ With the `rhoas` command-line interface (CLI), you can manage your application s
 
 This guide describes how to get started quickly by doing the following:
 
+--
 * Install `rhoas` on your Operating System.
 
 * Configure `rhoas` to enable command completion.
 
 * Start using `rhoas` by creating a simple Kafka instance, connecting to it, and creating a Kafka topic to produce and consume messages.
+--
 
 [id="proc-installing-rhoas_{context}"]
 == Installing the rhoas CLI


### PR DESCRIPTION
When split by asciidoc-splitter, a line break is removed between the intro and the first include. Asciidoctor can't process this correctly, because it's ambiguous whether the first include is part of the bulleted list or not. To fix the issue, I've enclosed the bulleted list in an open block to explicitly set it off from the subsequent include.