### PR TITLE
Fix quarkus guide link in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 
 * link:./getting-started[The Getting Started Guide]
 * link:./rhoas-cli[Using the RHOAS CLI]
-* link:./quarkus-kafka[Using {PRODUCT} with Quarkus]
+* link:./quarkus[Using {PRODUCT} with Quarkus]
 * link:./kafkacat[Using {PRODUCT} with Kafkacat]
 * link:./kafka-bin-scripts[Using {PRODUCT} with Kafka Bin Scripts]
 * link:./service-binding[Using Service Binding with {PRODUCT}]


### PR DESCRIPTION
Note that the service-binding guide doesn't appear to exist anymore. I didn't remove it from the README because I'm not sure if it will be coming back.