### PR TITLE
Fix typo in bin scripts quick start

### DIFF
--- a/kafka-bin-scripts/README.adoc
+++ b/kafka-bin-scripts/README.adoc
@@ -163,7 +163,7 @@ ifndef::qs[]
 * Verify that the `kafka-console-producer` script is still running without any errors in the terminal.
 endif::[]
 
-[id="proc-consuming-messages-kafka-bin-scripts_{context}""]
+[id="proc-consuming-messages-kafka-bin-scripts_{context}"]
 == Consuming messages using Kafka bin scripts
 
 You can use the `kafka-console-consumer` script to consume messages from Kafka topics. This example consumes the messages that you sent previously with the producer that you created with the `kafka-console-producer` script.


### PR DESCRIPTION
Fixes a typo in the anchor ID of the final section.