### PR TITLE
Quickstarts for DevSandbox

### DIFF
--- a/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
+++ b/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
@@ -154,4 +154,5 @@ spec:
   conclusion: >-
     You've successfully created a connection between a Red Hat managed cloud service and your OpenShift project/namespace.
     You can now start using this Kafka instance in your applications, for example by binding the service to a Quarkus microservice.
-
+  nextQuickStart:
+  - rhosak-devsandbox-quarkus-bind-cli-toolscontainer-quickstart

--- a/devsandbox-quickstarts/rhosak-devsandbox-getting-started-quickstart.yaml
+++ b/devsandbox-quickstarts/rhosak-devsandbox-getting-started-quickstart.yaml
@@ -1,0 +1,118 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: rhosak-devsandbox-getting-started-quickstart
+spec:
+  displayName: Getting Started with Red Hat OpenShift Streams for Apache Kafka
+  tags:     
+  - streams
+  - kafka
+  durationMinutes: 10
+  description: Learn how to set up your first Apache Kafka instance in Red Hat OpenShift Streams for Apache Kafka.
+  prerequisites:
+  - A Red Hat identity
+  - You're logged in to the Application Services web console at https://cloud.redhat.com/beta/application-services.
+  introduction: >-
+    Welcome to the Red Hat OpenShift Streams for Apache Kafka Getting Started quick start. 
+    In this quick start, you’ll learn how to inspect a Kafka instance, create a service account to connect an application or service to the instance, 
+    and create a topic in the instance.
+  tasks:
+  - title: Inspecting a Kafka instance in Streams for Apache Kafka
+    description: >-
+      Use the Streams for Apache Kafka web console to configure a Kafka instance for your applications or services. 
+      
+      
+      A Kafka instance has already been provisioned for you.
+      
+      
+      A Kafka instance in Streams for Apache Kafka includes a Kafka cluster, bootstrap server, and the configurations needed to connect to producer and consumer services.
+  
+      1. In the web console of Application Services, select **Kafka Instances** in the **Streams for Apache kafka** menu.
+
+      1. Your Kafka instance is listed in the instances table. When the instance **Status** is **Ready**, you can start using the Kafka instance. You can use the options icon (three vertical dots) to view and connect to the instance.
+    review:
+      instructions: |-
+        Is the new Kafka instance listed in the instances table?
+
+        Is the state of the new Kafka instance shown as **Ready**?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success: >-
+        You have completed this task!
+      failed: Try the steps again.
+  - title: Creating a service account to connect to a Kafka instance in Streams for Apache Kafka
+    description: >-
+      To connect your applications or services to a Kafka instance in the Streams for Apache Kafka web console, 
+      you need to create a service account, copy and save the generated credentials, and copy and save the bootstrap server endpoint. 
+      You’ll use the service account information later when you configure your application.
+
+      1. In the **Kafka Instances** page of the web console, for the relevant Kafka instance that you want to connect to, 
+      select the options icon (three vertical dots) and click **View connection information**.
+      
+      1. In the **Connection** page, copy the **Bootstrap server** endpoint to a secure location. 
+      This is the bootstrap server endpoint that you'll need for connecting to this Kafka instance.
+
+      1. Click **Create service account** to generate the credentials that you'll use to connect to this Kafka instance.
+
+      1. Copy the generated **Client ID** and **Client Secret** to a secure location.
+
+          IMPORTANT: The generated credentials are displayed only one time, 
+          so ensure that you have successfully and securely saved the copied credentials before closing the credentials window.
+
+      1. After you save the generated credentials to a secure location, select the confirmation check box in the credentials window and close the window.
+
+          You'll use the server and client information that you saved to configure your application to connect to your Kafka instances when you're ready. 
+          For example, if you plan to use [Kafkacat](https://github.com/edenhill/kafkacat) to interact with your Kafka instance, 
+          you'll use this information to set your bootstrap server and client environment variables.
+    review:
+      instructions: |-
+        Did you save the bootstrap server endpoint to a secure location?
+
+        Did you save the client credentials to a secure location?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success: >-
+        You have completed this task!
+      failed: Try the steps again.
+  - title: Creating a Kafka topic in Streams for Apache Kafka
+    description: >-
+      After you create a Kafka instance, you can create Kafka topics to start producing and consuming messages in your services.
+
+      1. In the **Kafka Instances** page of the web console, select the name of the Kafka instance that you want to add a topic to.
+      
+      1. Click **Create topic** and follow the guided steps to define the topic details. 
+      Click **Next** to complete each step and click **Finish** to complete the setup.
+
+          **Topic name**: Enter a unique topic name, such as ```my-first-kafka-topic```.
+
+          **Partitions**: Set the number of partitions for this topic. This example sets the partition to ```1``` for a single partition. 
+          Partitions are distinct lists of messages within a topic and enable parts of a topic to be distributed over multiple brokers in the cluster. 
+          A topic can contain one or more partitions, enabling producer and consumer loads to be scaled.
+
+          NOTE: You can increase the number of partitions later, but you cannot decrease them.
+
+          **Message retention**: Set the message retention time to the relevant value and increment. 
+          This example sets the retention to ```7 days```. 
+          Message retention time is the amount of time that messages are retained in a topic before they are deleted or compacted, depending on the cleanup policy.
+
+          **Replicas**: Set the number of partition replicas for the topic and the minimum number of follower replicas that must be in sync with a partition leader. 
+          In the current version of Streams for Apache Kafka the values are fixed and set to ```3``` for the number of replicas and ```2``` for the in-sync replicas. 
+          Replicas are copies of partitions in a topic. 
+          Partition replicas are distributed over multiple brokers in the cluster to ensure topic availability if a broker fails. 
+          When a follower replica is in sync with a partition leader, the follower replica can become the new partition leader if needed.
+
+      After you complete the topic setup, the new Kafka topic is listed in the topics table. 
+      You can now start producing and consuming messages to and from this topic using services that you connect to this instance.
+    review:
+      instructions: |-
+        Is the new Kafka topic listed in the topics table?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success: >-
+        You have completed this task!
+      failed: Try the steps again.
+  conclusion: >-
+    Congratulations! You successfully completed the Red Hat OpenShift Streams for Apache Kafka Getting Started quick start, 
+    and are now ready to use the service.
+  nextQuickStart:
+  - rhosak-devsandbox-kafkacat-toolscontainer

--- a/devsandbox-quickstarts/rhosak-devsandbox-kafkacat-toolscontainer.yaml
+++ b/devsandbox-quickstarts/rhosak-devsandbox-kafkacat-toolscontainer.yaml
@@ -1,0 +1,188 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: rhosak-devsandbox-kafkacat-toolscontainer
+spec:
+  displayName: Using Kafkacat with Kafka instances in Red Hat OpenShift Streams for Apache Kafka
+  tags:     
+  - streams
+  - kafka
+  durationMinutes: 10
+  description: Learn how to use Kafkacat to interact with a Kafka instance in Red Hat OpenShift Streams for Apache Kafka.
+  prerequisites:
+  - You have a running Kafka instance in Streams for Apache Kafka.
+  - You have the bootstrap server endpoint and the generated credentials for your service account.
+  introduction: >-
+    Welcome to the Red Hat OpenShift Streams for Apache Kafka Kafkacat quick start. 
+    In this quick start, you’ll learn how to use [Kafkacat](https://github.com/edenhill/kafkacat) to produce and consume messages for your Kafka instances in Streams for Apache Kafka.
+  tasks:
+  - title: Access Kafkacat
+    description: >-
+      [Kafkacat](https://github.com/edenhill/kafkacat) is a command-line utility for messaging in Apache Kafka 0.8 and later. 
+      You can install and use Kafkacat to test and debug your Kafka instances in Streams for Apache Kafka. 
+      With Kafkacat, you can produce and consume messages for your Kafka instances directly from the command line, 
+      and list topic and partition information for your Kafka instances.
+
+      
+      We've provided Kafkacat in an image that you can deploy in your OpenShift project. So you don't need to install Kafkacat on your own machine.
+
+
+      To install the tooling image, do the following (if you prefer to use a local installation of the Kafkacat, you can skip these steps):
+
+      1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+
+      1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+
+      1. Make sure that your OpenShift **Project**, which you can see at the top of the **Add** window, is set to `{username}-dev` (where *{username}* is your username in the DevSandbox OpenShift environment).
+
+      1. Click on the **Container Image** card.  
+
+      1. In the **Image name from external registry** field, enter: `quay.io/rhosak/rhoas-tools`.
+
+      1. In the *Runtime icon* field, select `openshift`.
+
+      1. Leave all the the fields set to their default values. 
+      You don't need a route for this application, so under the **Advanced Options** you can uncheck the **create a route to the Application** checkbox. 
+      Click the **Create** button. This will create a new OpenShift **Deployment** for the tools image.
+
+      1. You will see the deployment of the tools image in the **Topology** screen. The icon of the application should have a blue circle around it, indicating that the application has been deployed successfully.
+
+      1. Click on the icon of the tools application. This will open a panel on the righ-hand-side of your screen.
+      Click on the **Resources** tab. You will see the **Pods** of your Deployment. Currently we only have a single pod.
+
+      1. Click on the link to the pod. This opens the details page of the pod.
+
+      1. Open the **Terminal** tab. This opens a terminal inside the pod. To check whether you can access the required tooling, execute the command `kafkacat -V` in your terminal. 
+      This should print the Kafkacat version information.
+      
+          ```
+          kafkacat - Apache Kafka producer and consumer tool
+          https://github.com/edenhill/kafkacat
+          Copyright (c) 2014-2019, Magnus Edenhill
+          Version 1.6.0 (JSON, Avro, Transactions, librdkafka 1.5.0 builtin.features=gzip,snappy,ssl,sasl,regex,lz4,sasl_gssapi,sasl_plain,sasl_scram,plugins,zstd,sasl_oauthbearer)
+          ```
+    review:
+      instructions: |-
+        Did you see the Kafkacat version information in the terminal of the tooling pod?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success: >-
+        You have completed this task!
+      failed: Try the steps again.
+  - title: Configuring Kafkacat to connect to a Kafka instance
+    description: >-
+      To enable Kafkacat to access a Kafka instance, configure the connection using the bootstrap server endpoint and the generated credentials for your Streams for Apache Kafka service account. 
+      For Kafkacat, you can configure connection information either by passing options to the ```kafkacat``` command or by using a configuration file. 
+      The example in this task sets environment variables and then passes them to the ```kafkcat``` command.
+
+      
+      For more information about Kafkacat configuration options, see [Configuration](https://github.com/edenhill/kafkacat#configuration) in the Kafkacat documentation.
+
+      1. On the command line in the terminal of the tooling pod, enter the following commands to set the Kafka instance bootstrap server and client credentials as environment variables 
+      to be used by Kafkacat or other applications. Replace the values with your own server and credential information.
+
+          ```
+          $ export BOOTSTRAP_SERVER=__<bootstrap_server>__
+          $ export USER=__<client_id>__
+          $ export PASSWORD=__<client_secret>__
+          ```
+      
+    review:
+      instructions: |-
+        Have you completed this task?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success: >-
+        You have completed this task!
+      failed: Try the steps again.
+  - title: Producing messages in Kafkacat
+    description: >-
+      You can use Kafkacat to produce messages to Kafka topics in several ways, such as reading them from standard input (`stdin`) directly on the command line or from a file. 
+      This example produces messages from input on the command line. For more examples of Kafkacat producer messaging, see the [Examples](https://github.com/edenhill/kafkacat#examples) in the Kafkacat documentation.
+      
+      1. On the command line, enter the following commands to start Kafkacat in _producer_ mode. This mode enables you to produce messages to your Kafka topic.
+
+
+          This example uses the SASL/PLAIN authentication mechanism with the server and credential environment variables that you set previously. 
+          
+          This example produces messages to a topic in Streams for Apache Kafka named ```my-first-kafka-topic```. 
+          Replace the topic name with the relevant topic as needed. 
+          The topic that you use in this command must already exist in Streams for Apache Kafka.
+
+
+          Starting Kafkacat in producer mode:
+
+          ```
+          $ kafkacat -t my-first-kafka-topic -b "$BOOTSTRAP_SERVER" \
+           -X security.protocol=SASL_SSL -X sasl.mechanisms=PLAIN \
+           -X sasl.username="$USER" \
+           -X sasl.password="$PASSWORD" -P
+          ```
+
+          NOTE: Streams for Apache Kafka also supports the SASL/OAUTHBEARER mechanism for authentication, which is the recommended authentication mechanism to use. 
+          However, Kafkacat does not yet fully support OAUTHBEARER, so this example uses SASL/PLAIN.
+
+      1. With Kafkacat running in producer mode, enter messages into Kafkacat that you want to produce to the Kafka topic.
+
+
+          Example messages to produce to the Kafka topic:
+
+          ```
+          First message
+          Second message
+          Third message
+          ```
+      
+      1. Close the Kafkcat producer by entering ```Ctrl+C```.
+
+    review:
+      instructions: |-
+        Were you able to connect to your Kafka instance and send messages without errors?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success: >-
+        You have completed this task!
+      failed: Try the steps again.
+  - title: Consuming messages in Kafkacat
+    description: >-
+      You can use Kafkacat to consume messages from Kafka topics. 
+      This example consumes the messages that you sent previously with the producer that you created with Kafkacat.    
+
+      1. On the command line in the terminal of the tooling pod, enter the following commands to start Kafkacat in _consumer_ mode. 
+      This mode enables you to consume messages from your Kafka topic.
+  
+      
+          This example uses the SASL/PLAIN authentication mechanism with the server and credential environment variables that you set previously. 
+          This example consumes and displays the messages from the `my-first-kafka-topic` example topic, and states that it reached the end of partition `0` in the topic.
+
+
+          Starting Kafkacat in consumer mode:
+
+          ```
+          $ kafkacat -t my-first-kafka-topic -b "$BOOTSTRAP_SERVER" \
+           -X security.protocol=SASL_SSL -X sasl.mechanisms=PLAIN \
+           -X sasl.username="$USER" \
+           -X sasl.password="$PASSWORD" -C
+
+          First message
+          Second message
+          Third message
+          % Reached end of topic my-first-kafka-topic [0] at offset 3
+          ```
+
+      1. Close the Kafkcat producer by entering ```Ctrl+C```.  
+    review:
+      instructions: |-
+        Is your consumer running without any errors in the terminal?
+
+        Did the consumer display the messages from the `my-first-kafka-topic` example topic?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success: >-
+        You have completed this task!
+      failed: Try the steps again.
+  conclusion: >-
+    Congratulations! You successfully completed the {product} Kafkacat quick start, 
+    and are now ready to produce and consume messages in the service.
+  nextQuickStart:
+  - rhosak-devsandbox-connect-cli-toolscontainer-quickstart


### PR DESCRIPTION
Two more quickstarts to be deployed on DevSandbox and to be used for the Summit RHOSAK workshop.

The contents is very similar to the existing `Getting started` and `kafkacat` quickstarts, but adaptd to the workshop (kafka cluster already provisioned, kafkacat on installed a tools image).