### PR TITLE
Verify OpenShift guides

### DIFF
--- a/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
+++ b/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
@@ -143,7 +143,7 @@ spec:
         #### You have all the necessary information to connect your application to your OpenShift Streams for Apache Kafka instance:
         Have you seen the BootstrapServers field with hostname and port?
 
-        Do you know which authentication mechanism (SASL/PLAIN, SASL/OAUTHBEARER) to use?
+Do you know which authentication mechanism (SASL/PLAIN, SASL/OAUTHBEARER) will be used by Kafka?
 
         Do you know the name of the secret in which your **Client ID** and **Client Secret** are stored?
       failedTaskHelp: This task isn't verified yet. Try the task again.

--- a/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
+++ b/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
@@ -132,16 +132,16 @@ spec:
 
       1. Execute the following command to retrieve the details of your **KafkaConnection**. Replace *{kafka-connection-name}* with the name of your **KafkaConnection** resource: `oc describe KafkaConnection/{kafka-connection-name}`
     
-      1. The output of the previous command contains the details of your **KafkaConnection**. Try to find the **Bootstrap Server Host** setting of your **KafkaConnection**.
+      1. The output of the previous command contains the details of your **KafkaConnection**. Try to find the **BootstrapServers** setting of your **KafkaConnection**.
 
-      1. The **KafkaConnection** contains more information besides the **Bootstrap Server Host**. Try to find the **Sasl Mechanism** and the **Security Protocol**.
+      1. The **KafkaConnection** contains more information besides the **BootstrapServers**. Try to find the **Sasl Mechanism** and the **Security Protocol**.
 
       1. Finally the **KafkaConnection** has a reference to **Service Account Secret** that contains the **Client ID** and **Client Secret** needed to connect to the service. Try to find that configuration in your **KafkaConnection**.
 
     review:
       instructions: |-
         #### You have all the necessary information to connect your application to your OpenShift Streams for Apache Kafka instance:
-        Have you seen the Bootstrap Server hostname and port?
+        Have you seen the BootstrapServers field with hostname and port?
 
         Do you know which authentication mechanism (SASL/PLAIN, SASL/OAUTHBEARER) to use?
 

--- a/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
+++ b/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
@@ -153,6 +153,6 @@ spec:
       failed: Try the steps again.
   conclusion: >-
     You've successfully created a connection between a Red Hat managed cloud service and your OpenShift project/namespace.
-    You can now start using this Kafka instance in your applications, for example by binding the service to a Quarkus microservice.
+    You can now start using this Kafka instance in your applications, for example by binding the Kafka service to a Quarkus application.
   nextQuickStart:
   - rhosak-devsandbox-quarkus-bind-cli-toolscontainer-quickstart


### PR DESCRIPTION
During review I found possible improvements:

- Urls to token page are as plain text. (Adding link doesn't seem to make difference - possibly due to lack of support for links in the list view?
- We request token twice (this will give us 2 different tokens) we could possibly ask user to keep page open and use the same token for both login and connect command. (connect can be run in the interactive mode that will be more impressive - without kafka selection
- quay.io/rhosak/quarkus-kafka-sb-quickstart (we use rhoas and bf2 orgs) I haven't heard about rhosak. How to get access to this org?
