### PR TITLE
chore: fix npm security warnings

### DIFF
--- a/.build/package-lock.json
+++ b/.build/package-lock.json
@@ -4890,9 +4890,10 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "optional": true
     },
     "jquery-match-height": {
       "version": "0.7.2",
@@ -6190,6 +6191,13 @@
         "moment-timezone": "^0.4.1",
         "patternfly-bootstrap-combobox": "~1.1.7",
         "patternfly-bootstrap-treeview": "~2.1.10"
+      },
+      "dependencies": {
+        "jquery": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+          "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+        }
       }
     },
     "patternfly-bootstrap-combobox": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11743717/115260158-66c7ca80-a12a-11eb-8997-38784019404f.png)

I ran an `npm audit fix` which will hopefully (🤞🏻) remove the ugly warning banner on the repo homepage. If not we can probably dismiss the warnings through the GitHub UI.