### PR TITLE
Remove note about partitions

### DIFF
--- a/devsandbox-quickstarts/rhosak-devsandbox-getting-started-quickstart.yaml
+++ b/devsandbox-quickstarts/rhosak-devsandbox-getting-started-quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rhosak-devsandbox-getting-started-quickstart
 spec:
   displayName: Getting Started with Red Hat OpenShift Streams for Apache Kafka
-  tags:     
+  tags:
   - streams
   - kafka
   durationMinutes: 10
@@ -13,20 +13,20 @@ spec:
   - A Red Hat identity
   - You're logged in to the Application Services web console at https://cloud.redhat.com/beta/application-services.
   introduction: >-
-    Welcome to the Red Hat OpenShift Streams for Apache Kafka Getting Started quick start. 
-    In this quick start, you’ll learn how to inspect a Kafka instance, create a service account to connect an application or service to the instance, 
+    Welcome to the Red Hat OpenShift Streams for Apache Kafka Getting Started quick start.
+    In this quick start, you’ll learn how to inspect a Kafka instance, create a service account to connect an application or service to the instance,
     and create a topic in the instance.
   tasks:
   - title: Inspecting a Kafka instance in Streams for Apache Kafka
     description: >-
-      Use the Streams for Apache Kafka web console to configure a Kafka instance for your applications or services. 
-      
-      
+      Use the Streams for Apache Kafka web console to configure a Kafka instance for your applications or services.
+
+
       A Kafka instance has already been provisioned for you.
-      
-      
+
+
       A Kafka instance in Streams for Apache Kafka includes a Kafka cluster, bootstrap server, and the configurations needed to connect to producer and consumer services.
-  
+
       1. In the web console of Application Services, select **Kafka Instances** in the **Streams for Apache kafka** menu.
 
       1. Your Kafka instance is listed in the instances table. When the instance **Status** is **Ready**, you can start using the Kafka instance. You can use the options icon (three vertical dots) to view and connect to the instance.
@@ -42,27 +42,27 @@ spec:
       failed: Try the steps again.
   - title: Creating a service account to connect to a Kafka instance in Streams for Apache Kafka
     description: >-
-      To connect your applications or services to a Kafka instance in the Streams for Apache Kafka web console, 
-      you need to create a service account, copy and save the generated credentials, and copy and save the bootstrap server endpoint. 
+      To connect your applications or services to a Kafka instance in the Streams for Apache Kafka web console,
+      you need to create a service account, copy and save the generated credentials, and copy and save the bootstrap server endpoint.
       You’ll use the service account information later when you configure your application.
 
-      1. In the **Kafka Instances** page of the web console, for the relevant Kafka instance that you want to connect to, 
+      1. In the **Kafka Instances** page of the web console, for the relevant Kafka instance that you want to connect to,
       select the options icon (three vertical dots) and click **View connection information**.
-      
-      1. In the **Connection** page, copy the **Bootstrap server** endpoint to a secure location. 
+
+      1. In the **Connection** page, copy the **Bootstrap server** endpoint to a secure location.
       This is the bootstrap server endpoint that you'll need for connecting to this Kafka instance.
 
       1. Click **Create service account** to generate the credentials that you'll use to connect to this Kafka instance.
 
       1. Copy the generated **Client ID** and **Client Secret** to a secure location.
 
-          IMPORTANT: The generated credentials are displayed only one time, 
+          IMPORTANT: The generated credentials are displayed only one time,
           so ensure that you have successfully and securely saved the copied credentials before closing the credentials window.
 
       1. After you save the generated credentials to a secure location, select the confirmation check box in the credentials window and close the window.
 
-          You'll use the server and client information that you saved to configure your application to connect to your Kafka instances when you're ready. 
-          For example, if you plan to use [Kafkacat](https://github.com/edenhill/kafkacat) to interact with your Kafka instance, 
+          You'll use the server and client information that you saved to configure your application to connect to your Kafka instances when you're ready.
+          For example, if you plan to use [Kafkacat](https://github.com/edenhill/kafkacat) to interact with your Kafka instance,
           you'll use this information to set your bootstrap server and client environment variables.
     review:
       instructions: |-
@@ -79,29 +79,27 @@ spec:
       After you create a Kafka instance, you can create Kafka topics to start producing and consuming messages in your services.
 
       1. In the **Kafka Instances** page of the web console, click the name of the Kafka instance that you want to add a topic to.
-      
-      1. Click **Create topic** and follow the guided steps to define the topic details. 
+
+      1. Click **Create topic** and follow the guided steps to define the topic details.
       Click **Next** to complete each step and click **Finish** to complete the setup.
 
           **Topic name**: Enter a unique topic name, such as ```my-first-kafka-topic```.
 
-          **Partitions**: Set the number of partitions for this topic. This example sets the partition to ```1``` for a single partition. 
-          Partitions are distinct lists of messages within a topic and enable parts of a topic to be distributed over multiple brokers in the cluster. 
+          **Partitions**: Set the number of partitions for this topic. This example sets the partition to ```1``` for a single partition.
+          Partitions are distinct lists of messages within a topic and enable parts of a topic to be distributed over multiple brokers in the cluster.
           A topic can contain one or more partitions, enabling producer and consumer loads to be scaled.
 
-          NOTE: You can increase the number of partitions later, but you cannot decrease them.
-
-          **Message retention**: Set the message retention time to the relevant value and increment. 
-          This example sets the retention to ```7 days```. 
+          **Message retention**: Set the message retention time to the relevant value and increment.
+          This example sets the retention to ```7 days```.
           Message retention time is the amount of time that messages are retained in a topic before they are deleted or compacted, depending on the cleanup policy.
 
-          **Replicas**: Set the number of partition replicas for the topic and the minimum number of follower replicas that must be in sync with a partition leader. 
-          In the current version of Streams for Apache Kafka the values are fixed and set to ```3``` for the number of replicas and ```2``` for the in-sync replicas. 
-          Replicas are copies of partitions in a topic. 
-          Partition replicas are distributed over multiple brokers in the cluster to ensure topic availability if a broker fails. 
+          **Replicas**: Set the number of partition replicas for the topic and the minimum number of follower replicas that must be in sync with a partition leader.
+          In the current version of Streams for Apache Kafka the values are fixed and set to ```3``` for the number of replicas and ```2``` for the in-sync replicas.
+          Replicas are copies of partitions in a topic.
+          Partition replicas are distributed over multiple brokers in the cluster to ensure topic availability if a broker fails.
           When a follower replica is in sync with a partition leader, the follower replica can become the new partition leader if needed.
 
-      After you complete the topic setup, the new Kafka topic is listed in the topics table. 
+      After you complete the topic setup, the new Kafka topic is listed in the topics table.
       You can now start producing and consuming messages to and from this topic using services that you connect to this instance.
     review:
       instructions: |-
@@ -112,7 +110,7 @@ spec:
         You have completed this task!
       failed: Try the steps again.
   conclusion: >-
-    Congratulations! You successfully completed the Red Hat OpenShift Streams for Apache Kafka Getting Started quick start, 
+    Congratulations! You successfully completed the Red Hat OpenShift Streams for Apache Kafka Getting Started quick start,
     and are now ready to use the service.
   nextQuickStart:
   - rhosak-devsandbox-kafkacat-toolscontainer

--- a/getting-started/README.adoc
+++ b/getting-started/README.adoc
@@ -169,10 +169,6 @@ image::sak-create-topic.png[Image of wizard to create a topic]
 
 * *Topic name*: Enter a unique topic name, such as `my-first-kafka-topic`.
 * *Partitions*: Set the number of partitions for this topic. This example sets the partition to `1` for a single partition. Partitions are distinct lists of messages within a topic and enable parts of a topic to be distributed over multiple brokers in the cluster. A topic can contain one or more partitions, enabling producer and consumer loads to be scaled.
-+
-NOTE: You can increase the number of partitions later, but you cannot decrease them.
-+
-
 * *Message retention*: Set the message retention time and size to the relevant value and increment. This example sets the retention time to `7 days` and the retention size to `Unlimited`. Message retention time is the amount of time that messages are retained in a topic before they are deleted or compacted, depending on the cleanup policy. Retention size is the maximum total size of all log segments in a partition before they are deleted or compacted.
 * *Replicas*: For this release of {product}, the replicas are preconfigured. The number of partition replicas for the topic is set to `3` and the minimum number of follower replicas that must be in sync with a partition leader is set to `2`. Replicas are copies of partitions in a topic. Partition replicas are distributed over multiple brokers in the cluster to ensure topic availability if a broker fails. When a follower replica is in sync with a partition leader, the follower replica can become the new partition leader if needed.
 

--- a/quarkus/README.adoc
+++ b/quarkus/README.adoc
@@ -120,10 +120,6 @@ image::sak-create-topic.png[Image of wizard to create a topic]
 
 * *Topic name*: Enter `prices` as the topic name.
 * *Partitions*: Set the number of partitions for this topic. This example sets the partition to `1` for a single partition. Partitions are distinct lists of messages within a topic and enable parts of a topic to be distributed over multiple brokers in the cluster. A topic can contain one or more partitions, enabling producer and consumer loads to be scaled.
-+
-NOTE: You can increase the number of partitions later, but you cannot decrease them.
-+
-
 * *Message retention*: Set the message retention time and size to the relevant value and increment. This example sets the retention time to `7 days` and the retention size to `Unlimited`. Message retention time is the amount of time that messages are retained in a topic before they are deleted or compacted, depending on the cleanup policy. Retention size is the maximum total size of all log segments in a partition before they are deleted or compacted.
 * *Replicas*: For this release of {product}, the replicas are preconfigured. The number of partition replicas for the topic is set to `3` and the minimum number of follower replicas that must be in sync with a partition leader is set to `2`. Replicas are copies of partitions in a topic. Partition replicas are distributed over multiple brokers in the cluster to ensure topic availability if a broker fails. When a follower replica is in sync with a partition leader, the follower replica can become the new partition leader if needed.
 +


### PR DESCRIPTION
Addresses the following Jiras:
* https://issues.redhat.com/browse/MGDSTRM-3039 - Remove note about number of partitions
* https://issues.redhat.com/browse/MGDSTRM-3022 - Clarify Kafkacat with stdin

@b1zzu Can you please review and verify? Fixes your reported bugs.

@b1zzu However, can you please clarify what changes you're suggesting for the `stdin` bit, something about using a `|` instead? I don't follow. Here's how it currently reads:

```
. On the command line, enter the following commands to start Kafkacat in _producer_ mode. This mode enables you to produce messages to your Kafka topic.
+
--
This example uses the SASL/PLAIN authentication mechanism with the server and credential environment variables that you set previously. This example produces messages to a topic in {product} named `my-first-kafka-topic`. Replace the topic name with the relevant topic as needed. The topic that you use in this command must already exist in {product}.

.Starting Kafkacat in producer mode
[source]
----
$ kafkacat -t my-first-kafka-topic -b "$BOOTSTRAP_SERVER" \
 -X security.protocol=SASL_SSL -X sasl.mechanisms=PLAIN \
 -X sasl.username="$USER" \
 -X sasl.password="$PASSWORD" -P
----
```