### PR TITLE
Update rhoas version number in CLI getting started guide

### DIFF
--- a/rhoas-cli/README.adoc
+++ b/rhoas-cli/README.adoc
@@ -48,11 +48,11 @@ $ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/m
 
 [NOTE]
 ====
-You can use the `-s` argument to install a specific version of the `rhoas` CLI. For example, this command installs version `0.19.0`:
+You can use the `-s` argument to install a specific version of the `rhoas` CLI. For example, this command installs version `0.23.1`:
 
 [source,shell]
 ----
-$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash -s 0.19.0
+$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash -s 0.23.1
 ----
 ====
 
@@ -73,12 +73,12 @@ $ echo $PATH
 . Check the `rhoas` version to verify that the CLI is installed.
 +
 --
-This example shows that `rhoas` 0.19.0 is installed:
+This example shows that `rhoas` 0.24.1 is installed:
 
 [source,shell]
 ----
 $ rhoas --version
-rhoas version 0.19.0
+rhoas version 0.24.1
 ----
 --
 
@@ -129,11 +129,11 @@ $ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/m
 
 [NOTE]
 ====
-You can use the `-s` argument to install a specific version of the `rhoas` CLI. For example, this command installs version `0.19.0`:
+You can use the `-s` argument to install a specific version of the `rhoas` CLI. For example, this command installs version `0.23.1`:
 
 [source,shell]
 ----
-$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash -s 0.19.0
+$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash -s 0.23.1
 ----
 ====
 
@@ -154,12 +154,12 @@ $ echo $PATH
 . Check the `rhoas` version to verify that the CLI is installed.
 +
 --
-This example shows that `rhoas` 0.19.0 is installed:
+This example shows that `rhoas` 0.24.1 is installed:
 
 [source,shell]
 ----
 $ rhoas --version
-rhoas version 0.19.0
+rhoas version 0.24.1
 ----
 --
 


### PR DESCRIPTION
Update the version number to 0.24.1 (the current version).

There are a couple examples that show how to install an older version of the CLI. I changed those version numbers to 0.23.1 (the first "production" version).