### PR TITLE
Add JDK prereq to bin scripts.

### DIFF
--- a/getting-started/README.adoc
+++ b/getting-started/README.adoc
@@ -35,11 +35,13 @@ As a developer of applications and services, you can use {product-long} to creat
 
 //For more overview information about {product}, see [variablized link to overview here https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/].
 
-ifndef::community[]
 .Prerequisites
+ifndef::community[]
 * You have a Red Hat account.
 //* You have a subscription to {product-long}. For more information about signing up, see *<@SME: Where to link?>*.
 endif::[]
+* https://adoptopenjdk.net/[JDK^] 11 or later is installed.
+* For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
 
 // Condition out QS-only content so that it doesn't appear in docs.
 // All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.

--- a/getting-started/quickstart.yml
+++ b/getting-started/quickstart.yml
@@ -16,6 +16,8 @@ spec:
   prerequisites:
     - A Red Hat identity
     - Access to the Red Hat OpenShift Streams for Apache Kafka environment at https://cloud.redhat.com
+    - JDK 11 or later
+    - For Windows, the latest version of Oracle JDK
   introduction: !snippet README.adoc#introduction
   tasks:
     - !snippet/proc README.adoc#proc-creating-kafka-instance

--- a/kafka-bin-scripts/README.adoc
+++ b/kafka-bin-scripts/README.adoc
@@ -42,6 +42,7 @@ ifndef::community[]
 * You have a Red Hat account.
 endif::[]
 * You have a running Kafka instance in {product}.
+* https://adoptopenjdk.net/[JDK^] 11 or later is installed.
 * For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
 
 ifdef::qs[]

--- a/kafka-bin-scripts/quickstart.yml
+++ b/kafka-bin-scripts/quickstart.yml
@@ -16,6 +16,7 @@ spec:
   prerequisites:
     - A running Kafka instance (see the Getting Started quick start)
     - A command-line terminal application
+    - JDK 11 or later
     - For Windows, the latest version of Oracle JDK
   introduction: !snippet README.adoc#introduction
   tasks:

--- a/kafkacat/README.adoc
+++ b/kafkacat/README.adoc
@@ -39,6 +39,8 @@ ifndef::community[]
 endif::[]
 //* You have a subscription to {product-long}. For more information about signing up, see *<@SME: Where to link?>*.
 * You have a running Kafka instance in {product}.
+* https://adoptopenjdk.net/[JDK^] 11 or later is installed.
+* For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
 
 // Condition out QS-only content so that it doesn't appear in docs.
 // All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.

--- a/kafkacat/quickstart.yml
+++ b/kafkacat/quickstart.yml
@@ -16,6 +16,8 @@ spec:
   prerequisites:
     - A running Kafka instance (see the Getting Started quick start)
     - A command-line terminal application
+    - JDK 11 or later
+    - For Windows, the latest version of Oracle JDK
   introduction: !snippet README.adoc#introduction
   tasks:
     - !snippet/proc README.adoc#proc-installing-kafkacat


### PR DESCRIPTION
@pmuir @bhardesty, I got a ping from @jgiardino about the following user feedback for the bin scripts quick start:

>The prerequisites mention only latest JDK for Windows, but I'm on macOS. I'd say we need to add the requirement for the latest JDK regardless of the OS.

He's referring to the Oracle JDK prereq which is mentioned "For Windows". In the Quarkus quick start, we mention both JDK 11+ and Oracle JDK for Windows but in the bin scripts we mention only the Oracle JDK for Windows, nothing about JDK 11+. So I _think_ the user is confused because he's misreading that to mean the JDK 11? Or does the Oracle JDK apply to MacOS too? I've pushed this PR to add the JDK 11 prereq to the bin scripts quick start. Is this the right way to clarify so that it's clear what applies to Windows only, or do we just need to make the Oracle JDK apply to all OS? Not sure what to do here.

Thanks