### PR TITLE
[DOC] CLI consumer group reset

### DIFF
--- a/rhoas-cli/README.adoc
+++ b/rhoas-cli/README.adoc
@@ -571,7 +571,7 @@ view the command help (for example, `rhoas kafka list -h`).
 
 * Reset partition offsets for a particular consumer group and its members:
 +
-`rhoas kafka consumergroup reset-offset`
+`rhoas kafka consumer-group reset-offset`
 
 * Delete a Kafka consumer group and its members:
 +

--- a/rhoas-cli/README.adoc
+++ b/rhoas-cli/README.adoc
@@ -569,6 +569,10 @@ view the command help (for example, `rhoas kafka list -h`).
 +
 `rhoas kafka consumer-group describe`
 
+* Reset partition offsets for a particular consumer group and its members:
++
+`rhoas kafka consumergroup reset-offset`
+
 * Delete a Kafka consumer group and its members:
 +
 `rhoas kafka consumer-group delete`


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Updated the _Commands for managing Kafka section_ in [Getting started with the rhoas CLI](https://github.com/redhat-developer/app-services-guides/tree/main/rhoas-cli#getting-started-with-the-rhoas-cli) with consumer group command to reset partitions.

Preview: http://file.emea.redhat.com/pmellor/docs/managed-kafka-drafts/getting-started-cli.html#_commands_for_managing_kafka