### PR TITLE
[DOC] update the CLI version references

### DIFF
--- a/rhoas-cli/README.adoc
+++ b/rhoas-cli/README.adoc
@@ -48,11 +48,11 @@ $ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/m
 
 [NOTE]
 ====
-You can use the `-s` argument to install a specific version of the `rhoas` CLI. For example, this command installs version `0.24.3`:
+You can use the `-s` argument to install a specific version of the `rhoas` CLI. For example, this command installs version `0.25.0`:
 
 [source,shell]
 ----
-$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash -s 0.24.3
+$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash -s 0.25.0
 ----
 ====
 
@@ -73,12 +73,12 @@ $ echo $PATH
 . Check the `rhoas` version to verify that the CLI is installed.
 +
 --
-This example shows that `rhoas` 0.24.3 is installed:
+This example shows that `rhoas` 0.25.0 is installed:
 
 [source,shell]
 ----
 $ rhoas --version
-rhoas version 0.24.3
+rhoas version 0.25.0
 ----
 --
 
@@ -93,23 +93,23 @@ You can install `rhoas` as an RPM if you are using Red Hat Enterprise Linux (RHE
 . Use `dnf`/`yum` to install the desired version of `rhoas`:
 +
 --
-This example installs `rhoas` version `0.24.3`:
+This example installs `rhoas` version `0.25.0`:
 
 [source,shell]
 ----
-$ sudo dnf install -y https://github.com/redhat-developer/app-services-cli/releases/download/0.24.3/rhoas_0.24.3_linux_amd64.rpm
+$ sudo dnf install -y https://github.com/redhat-developer/app-services-cli/releases/download/0.25.0/rhoas_0.25.0_linux_amd64.rpm
 ----
 --
 
 . Check the `rhoas` version to verify that the CLI is installed.
 +
 --
-This example shows that `rhoas` 0.24.3 is installed:
+This example shows that `rhoas` 0.25.0 is installed:
 
 [source,shell]
 ----
 $ rhoas --version
-rhoas version 0.24.3
+rhoas version 0.25.0
 ----
 --
 
@@ -129,11 +129,11 @@ $ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/m
 
 [NOTE]
 ====
-You can use the `-s` argument to install a specific version of the `rhoas` CLI. For example, this command installs version `0.24.3`:
+You can use the `-s` argument to install a specific version of the `rhoas` CLI. For example, this command installs version `0.25.0`:
 
 [source,shell]
 ----
-$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash -s 0.24.3
+$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash -s 0.25.0
 ----
 ====
 
@@ -154,12 +154,12 @@ $ echo $PATH
 . Check the `rhoas` version to verify that the CLI is installed.
 +
 --
-This example shows that `rhoas` 0.24.3 is installed:
+This example shows that `rhoas` 0.25.0 is installed:
 
 [source,shell]
 ----
 $ rhoas --version
-rhoas version 0.24.3
+rhoas version 0.25.0
 ----
 --
 


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Updates the CLI version references from `0.24.3` to `0.25.0` in the _Getting started with the rhoas CLI_ guide.