### PR TITLE
[DOC] add group ID config to quickstarts

### DIFF
--- a/kafka-bin-scripts/README.adoc
+++ b/kafka-bin-scripts/README.adoc
@@ -124,14 +124,13 @@ endif::[]
 
 . Create a file called `{property-file-name}`.
 
-. In the `{property-file-name}` file, add the following content to set the Kafka instance client credentials. Replace the values with your own server and credential information.
+. In the `{property-file-name}` file, set the Kafka instance client credentials and consumer group ID. Replace the values with your own server and credential information.
 +
 --
 ifdef::qs[]
 The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots), clicking *View connection information*, and creating the service account.
 endif::[]
 
-Add a group ID for the consumer to be able to join a consumer group.
 All consumers with the same group ID belong to the consumer group with that ID.
 
 .Setting server and credential values

--- a/kafka-bin-scripts/README.adoc
+++ b/kafka-bin-scripts/README.adoc
@@ -131,6 +131,9 @@ ifdef::qs[]
 The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots), clicking *View connection information*, and creating the service account.
 endif::[]
 
+Add a group ID for the consumer to be able to join a consumer group.
+All consumers with the same group ID belong to the consumer group with that ID.
+
 .Setting server and credential values
 [source,subs="+quotes"]
 ----
@@ -139,7 +142,8 @@ security.protocol=SASL_SSL
 
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
   username="__<client_id>__" \
-  password="__<client_secret>__";
+  password="__<client_secret>__" \
+  group.id="__<consumer_group_id>__";
 ----
 
 NOTE: {product} also supports the SASL/OAUTHBEARER mechanism for authentication, which is the recommended authentication mechanism to use. However, the Kafka bin scripts do not yet fully support OAUTHBEARER, so this example uses SASL/PLAIN.

--- a/kafkacat/README.adoc
+++ b/kafkacat/README.adoc
@@ -111,17 +111,23 @@ endif::[]
 .Procedure
 * On the command line, enter the following commands to set the Kafka instance bootstrap server and client credentials as environment variables to be used by Kafkacat or other applications. Replace the values with your own server and credential information.
 +
+--
 ifdef::qs[]
 The `<bootstrap_server>` is the bootstrap server endpoint for your service account. The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots) and clicking *View connection information*.
-+
 endif::[]
+
+Add a group ID for the consumer to be able to join a consumer group.
+All consumers with the same group ID belong to the consumer group with that ID.
+
 .Setting environment variables for server and credentials
 [source,subs="+quotes"]
 ----
 $ export BOOTSTRAP_SERVER=__<bootstrap_server>__
 $ export USER=__<client_id>__
 $ export PASSWORD=__<client_secret>__
+$ export GROUP_ID=__<group_id>__
 ----
+--
 
 [id="proc-producing-messages-kafkacat_{context}"]
 == Producing messages in Kafkacat

--- a/kafkacat/README.adoc
+++ b/kafkacat/README.adoc
@@ -109,7 +109,7 @@ ifndef::qs[]
 endif::[]
 
 .Procedure
-* On the command line, enter the following commands to set the Kafka instance bootstrap server, client credentials, and consumer group ID as environment variables to be used by Kafkacat or other applications. Replace the values with your own server and credential information.
+* On the command line, set the Kafka instance bootstrap server, client credentials, and consumer group ID as environment variables to be used by Kafkacat or other applications. Replace the values with your own server and credential information.
 +
 --
 ifdef::qs[]

--- a/kafkacat/README.adoc
+++ b/kafkacat/README.adoc
@@ -109,14 +109,13 @@ ifndef::qs[]
 endif::[]
 
 .Procedure
-* On the command line, enter the following commands to set the Kafka instance bootstrap server and client credentials as environment variables to be used by Kafkacat or other applications. Replace the values with your own server and credential information.
+* On the command line, enter the following commands to set the Kafka instance bootstrap server, client credentials, and consumer group ID as environment variables to be used by Kafkacat or other applications. Replace the values with your own server and credential information.
 +
 --
 ifdef::qs[]
 The `<bootstrap_server>` is the bootstrap server endpoint for your service account. The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots) and clicking *View connection information*.
 endif::[]
 
-Add a group ID for the consumer to be able to join a consumer group.
 All consumers with the same group ID belong to the consumer group with that ID.
 
 .Setting environment variables for server and credentials

--- a/quarkus/README.adoc
+++ b/quarkus/README.adoc
@@ -100,7 +100,7 @@ ifndef::qs[]
 endif::[]
 
 .Procedure
-. On the command line, enter the following commands to set the Kafka instance bootstrap server, client credentials, and consumer group ID as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
+. On the command line, set the Kafka instance bootstrap server, client credentials, and consumer group ID as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
 +
 --
 ifdef::qs[]

--- a/quarkus/README.adoc
+++ b/quarkus/README.adoc
@@ -100,14 +100,13 @@ ifndef::qs[]
 endif::[]
 
 .Procedure
-. On the command line, enter the following commands to set the Kafka instance bootstrap server and client credentials as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
+. On the command line, enter the following commands to set the Kafka instance bootstrap server, client credentials, and consumer group ID as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
 +
 --
 ifdef::qs[]
 The `<bootstrap_server>` is the bootstrap server endpoint for your service account. The `<oauth_token_endpoint_uri>` is the SASL/OAUTHBEARER token endpoint for the Kafka instance. The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots) and clicking *View connection information*.
 endif::[]
 
-Add a group ID for the consumer to be able to join a consumer group.
 All consumers with the same group ID belong to the consumer group with that ID.
 
 .Setting environment variables for server and credentials

--- a/quarkus/README.adoc
+++ b/quarkus/README.adoc
@@ -102,18 +102,24 @@ endif::[]
 .Procedure
 . On the command line, enter the following commands to set the Kafka instance bootstrap server and client credentials as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
 +
+--
 ifdef::qs[]
 The `<bootstrap_server>` is the bootstrap server endpoint for your service account. The `<oauth_token_endpoint_uri>` is the SASL/OAUTHBEARER token endpoint for the Kafka instance. The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots) and clicking *View connection information*.
-+
 endif::[]
+
+Add a group ID for the consumer to be able to join a consumer group.
+All consumers with the same group ID belong to the consumer group with that ID.
+
 .Setting environment variables for server and credentials
 [source,subs="+quotes"]
 ----
-export BOOTSTRAP_SERVER=__<bootstrap_server>__
-export CLIENT_ID=__<client_id>__
-export CLIENT_SECRET=__<client_secret>__
-export OAUTH_TOKEN_ENDPOINT_URI=__<oauth_token_endpoint_uri>__
+$ export BOOTSTRAP_SERVER=__<bootstrap_server>__
+$ export CLIENT_ID=__<client_id>__
+$ export CLIENT_SECRET=__<client_secret>__
+$ export GROUP_ID=__<group_id>__
+$ export OAUTH_TOKEN_ENDPOINT_URI=__<oauth_token_endpoint_uri>__
 ----
+--
 . In the Quarkus example application, review the `src/main/resources/application.properties` file to understand how the environment variables you set in the previous step are used in your application. This example uses the `dev` configuration profile in the `application.properties` file.
 
 ifdef::qs[]


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Updates the quickstarts to include _group ID_ configuration for consumer groups.