### PR TITLE
Update "quick start" capitalization and spacing for consistency, and some broken community links

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Quick Start build
+name: Quick start build
 
 on:
   push:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -41,7 +41,7 @@ npm --prefix .build run generate:attributes
 
 == Repository structure
 
-This repository is designed to be usable for people browsing it on GitHub, as well as reusable (e.g. in Quick Starts) in implementations of {Product}.
+This repository is designed to be usable for people browsing it on GitHub, as well as reusable (e.g. in quick starts) in implementations of {Product}.
 
 Each guide is contained in a separate directory. The directory must contain:
 
@@ -94,11 +94,11 @@ A check exists in the continuous integration job that validates that generation 
 
 The file `.adocignore` contains a list of globs which will be ignored by the attribute injector (e.g. this file).
 
-== Creating a Quick Start
+== Creating a quick start
 
-Many of the guides in this repository are also available as "Quick Starts". Quick Starts are available in the Web UI for the {Product} and are based on the link:https://github.com/cloudmosaic/quickstarts[cloudmosaic] project.
+Many of the guides in this repository are also available as "quick starts". Quick starts are available in the Web UI for the {Product} and are based on the link:https://github.com/cloudmosaic/quickstarts[cloudmosaic] project.
 
-We would always recommend starting with a guide and then adding the Quick Start metadata. This will allow your content to be accessible both in the Web UI and via GitHub.
+We would always recommend starting with a guide and then adding the quick start metadata. This will allow your content to be accessible both in the Web UI and via GitHub.
 
 === Adding support for quickstart.yml to your IDE
 
@@ -140,7 +140,7 @@ export ATTRIBUTES_FILE=<path to attributes file>
 npm run start:dev
 ----
 
-=== Converting your guide into a Quick Start
+=== Converting your guide into a quick start
 
 . Add a `quickstart.yml` file to the same directory as the `README.adoc` for the guide.
 +
@@ -170,7 +170,7 @@ spec:
   displayName: !snippet/title README.adoc#<id>
 ----
 +
-The `!<tag name>` syntax represents a custom data type in YAML. When the `quickstart.yml` document is deserialized by the YAML parser, the quick start renderer is able to inject content. The `quickstart.yml` parser makes use of custom data types to inject content from an AsciiDoc file into the Quick Start. This allows us to better comply with the DRY principle.
+The `!<tag name>` syntax represents a custom data type in YAML. When the `quickstart.yml` document is deserialized by the YAML parser, the quick start renderer is able to inject content. The `quickstart.yml` parser makes use of custom data types to inject content from an AsciiDoc file into the quick start. This allows us to better comply with the DRY principle.
 +
 The tag `!snippet/title` allows us to use a link:https://asciidoctor.org/docs/asciidoc-writers-guide/#titles-titles-titles[title] from an AsciiDoc file. In order to this we provide the relative path to an AsciiDoc source file (in this case the `README.adoc` that contains the guide content), followed by the `##` symbol, followed by the link:https://docs.asciidoctor.org/asciidoc/latest/sections/custom-ids/[id] of a link:https://docs.asciidoctor.org/asciidoc/latest/blocks/[block].
 +
@@ -239,7 +239,7 @@ Here are some examples:
 
 link:https://github.com/redhataccess/pantheon[Pantheon 2.x] is a modular documentation management and publication system built on top of AsciiDoc.
 
-NOTE: Currently, Pantheon is integrated with Quick Starts during the Webpack build, meaning that to refresh the content you must rebuild the Quick Starts.
+NOTE: Currently, Pantheon is integrated with quick starts during the Webpack build, meaning that to refresh the content you must rebuild the quick starts.
 
 In order to use content published by Pantheon you must map the `!snippet` and `snippet/*` tags that need to use Pantheon to a Pantheon UUID and type. Additionally, you must provide the base URL of your Pantheon server.
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,24 +1,24 @@
 :PRODUCT: App Services
 
-= {PRODUCT} Guides & Samples
+= {PRODUCT} Guides and samples
 
 == Guides
 
-* link:./getting-started[The Getting Started Guide]
-* link:./rhoas-cli[Using the RHOAS CLI]
-* link:./quarkus[Using {PRODUCT} with Quarkus]
-* link:./kafkacat[Using {PRODUCT} with Kafkacat]
-* link:./kafka-bin-scripts[Using {PRODUCT} with Kafka Bin Scripts]
-* link:./service-discovery[Service Discovery and Binding in your OpenShift Cluster {PRODUCT}]
+* link:./getting-started[Getting started with {PRODUCT}]
+* link:./rhoas-cli[Getting started with the `rhoas` CLI]
+* link:./quarkus[Using Quarkus applications with Kafka instances in {PRODUCT}]
+* link:./kafkacat[Using Kafkacat with Kafka instances in {PRODUCT}]
+* link:./kafka-bin-scripts[Using Kafka bin scripts with {PRODUCT}]
+* link:./service-discovery[Binding OpenShift applications to {PRODUCT}]
 
-== OpenShift Quickstarts
+== OpenShift quick starts
 
-* link:./devsandbox-quickstarts[OpenShift Quick Starts]
+* link:./devsandbox-quickstarts[OpenShift quick starts]
 
-== Application Examples used in Guides
+== Application examples used in guides
 
-* link:./code-examples/quarkus-kafka-quickstart[Quarkus example]
+* link:./code-examples/quarkus-kafka-quickstart[Quarkus Kafka quick start]
 
 == Contributing
 
-* link:./CONTRIBUTING.adoc[Creating new guide]
+* link:./CONTRIBUTING.adoc[Contributing to {PRODUCT} guides]

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@
 
 == OpenShift quick starts
 
-* link:./devsandbox-quickstarts[OpenShift quick starts]
+* link:https://github.com/redhat-developer/app-services-operator/tree/main/olm/quickstarts[OpenShift quick starts]
 
 == Application examples used in guides
 

--- a/code-examples/quarkus-kafka-quickstart/README.md
+++ b/code-examples/quarkus-kafka-quickstart/README.md
@@ -1,4 +1,4 @@
-Quarkus Kafka Quickstart
+Quarkus Kafka quick start
 ========================
 To see how to use this code example follow the [quick start](../../quarkus).
 

--- a/getting-started/README.adoc
+++ b/getting-started/README.adoc
@@ -120,7 +120,7 @@ endif::[]
 ////
 // Commenting out the following for now, which belongs in an onboarding tour (Stetson, 4 March 2021)
 
-When you're in the {Product_short} environment, you will see a left menu panel. This panel provides access to all resources related to the service, including the `Quick Starts` and `Documentation`.
+When you're in the {Product_short} environment, you will see a left menu panel. This panel provides access to all resources related to the service, including the `Quick starts` and `Documentation`.
 
 In the lower left of the screen you'll see a lightbulb icon. This icon gives access to the `Resource Center`. Here you can find the latest information about the service, like product updates, upcoming events, etc.
 

--- a/quickstart.schema.json
+++ b/quickstart.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://github.com/redhat-developer/app-services-guides/quickstart.schema.json",
   "type": "object",
-  "title": "A Quick Start",
+  "title": "A quick start",
   "examples": [
     {
       "apiVersion": "console.openshift.io/v1",
@@ -169,7 +169,7 @@
     "spec": {
       "$id": "#/properties/spec",
       "type": "object",
-      "description": "Specification of the Quick Start",
+      "description": "Specification of the quick start",
       "examples": [
         {
           "version": 4.7,
@@ -244,7 +244,7 @@
         "version": {
           "$id": "#/properties/spec/properties/version",
           "type": "number",
-          "description": "The version of the Quick Start",
+          "description": "The version of the quick start",
           "default": 0.0,
           "examples": [
             4.7
@@ -444,7 +444,7 @@
               {
                 "$id": "#/properties/spec/properties/tasks/items/anyOf/1",
                 "type": "object",
-                "description": "A full description of the Quick Start",
+                "description": "A full description of the quick start",
                 "examples": [
                   {
                     "title": "Installing the OpenShift Pipelines Operator",
@@ -471,7 +471,7 @@
                   "title": {
                     "$id": "#/properties/spec/properties/tasks/items/anyOf/2/properties/title",
                     "type": "string",
-                    "description": "The title of the Quick Start",
+                    "description": "The title of the quick start",
                     "examples": [
                       "Installing the OpenShift Pipelines Operator"
                     ]
@@ -479,7 +479,7 @@
                   "description": {
                     "$id": "#/properties/spec/properties/tasks/items/anyOf/2/properties/description",
                     "type": "string",
-                    "description": "The body of the Quick Start",
+                    "description": "The body of the quick start",
                     "default": "",
                     "examples": [
                       "### To install the OpenShift Pipelines Operator:\n\n1. From the **Administrator** perspective in the console navigation panel, click **Operators > OperatorHub**.\n2. In the **Filter by keyword** field, type `OpenShift Pipelines Operator`.\n3. If the tile has an Installed label, the Operator is already installed. Proceed to the next quick start to create a Pipeline.\n4. Click the **tile** to open the Operator details.\n5. At the top of the OpenShift Pipelines Operator panel that opens, click **Install**.\n6. Fill out the Operator subscription form by selecting the channel that matches your OpenShift cluster, and then click **Install**.\n7. On the **Installed Operators** page, wait for the OpenShift Pipelines Operator's status to change from **Installing** to **Succeeded**. "
@@ -488,7 +488,7 @@
                   "review": {
                     "$id": "#/properties/spec/properties/tasks/items/anyOf/2/properties/review",
                     "type": "object",
-                    "description": "The messages used review the Quick Start",
+                    "description": "The messages used review the quick start",
                     "default": {},
                     "examples": [
                       {
@@ -519,7 +519,7 @@
                   "summary": {
                     "$id": "#/properties/spec/properties/tasks/items/anyOf/3/properties/summary",
                     "type": "object",
-                    "description": "The summary screen for the Quick Start task",
+                    "description": "The summary screen for the quick start task",
                     "default": {},
                     "examples": [
                       {


### PR DESCRIPTION
Details in [Jira](https://issues.redhat.com/browse/MAKDOC-277). I ensured that globally we are saying "quick start" two words, lowercase, except in headings ("Quick start"), and except in certain code that specifically uses one word as part of the build requirements and resource names, such as `QuickStart`, etc.