### PR TITLE
quarkus-kafka-quickstart: Added kafka.bootstrap.servers property to application.propeties

### DIFF
--- a/code-examples/quarkus-kafka-quickstart/src/main/resources/application.properties
+++ b/code-examples/quarkus-kafka-quickstart/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 # Quarkus config
 quarkus.ssl.native=true
 
+# Kafka bootstrap server
+kafka.bootstrap.servers=localhost:9092
+
 # Configure the Kafka sink (we write to it)
 mp.messaging.outgoing.generated-price.connector=smallrye-kafka
 mp.messaging.outgoing.generated-price.topic=prices


### PR DESCRIPTION
The quarkus-kafka-quickstart app is used in the `Binding your Quarkus application to Streams for Apache Kafka` quickstart in the developer sandbox.
When deploying the app without service binding, the app crashes with the following error message:
```
Sep 09, 2021 9:21:09 AM io.quarkus.runtime.ApplicationLifecycleManager run
ERROR: Failed to start application (with profile prod)
java.lang.IllegalStateException: The property 'kafka.bootstrap.servers' must be set when 'quarkus.kubernetes-service-binding.enabled' has been set to 'true'
	at io.quarkus.kafka.client.runtime.KafkaRecorder.checkBoostrapServers(KafkaRecorder.java:85)
	at io.quarkus.deployment.steps.KafkaProcessor$checkBoostrapServers-1072202763.deploy_0(KafkaProcessor$checkBoostrapServers-1072202763.zig:67)
	at io.quarkus.deployment.steps.KafkaProcessor$checkBoostrapServers-1072202763.deploy(KafkaProcessor$checkBoostrapServers-1072202763.zig:40)
	at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:447)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:101)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:66)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:42)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:119)
	at io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:29)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:48)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:25)
```
This is fixed by adding `kafka.bootstrap.servers=localhost:9092` to the `application.properties`.