### PR TITLE
chore: remove invalid env variable

### DIFF
--- a/quarkus/README.adoc
+++ b/quarkus/README.adoc
@@ -109,8 +109,6 @@ ifdef::qs[]
 The `<bootstrap_server>` is the bootstrap server endpoint for your service account. The `<oauth_token_endpoint_uri>` is the SASL/OAUTHBEARER token endpoint for the Kafka instance. The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots) and clicking *Connection*.
 endif::[]
 
-All consumers with the same group ID belong to the consumer group with that ID.
-
 .Setting environment variables for server and credentials
 [source,subs="+quotes"]
 ----

--- a/quarkus/README.adoc
+++ b/quarkus/README.adoc
@@ -117,7 +117,6 @@ All consumers with the same group ID belong to the consumer group with that ID.
 $ export BOOTSTRAP_SERVER=__<bootstrap_server>__
 $ export CLIENT_ID=__<client_id>__
 $ export CLIENT_SECRET=__<client_secret>__
-$ export GROUP_ID=__<group_id>__
 $ export OAUTH_TOKEN_ENDPOINT_URI=__<oauth_token_endpoint_uri>__
 ----
 --

--- a/quarkus/README.adoc
+++ b/quarkus/README.adoc
@@ -102,7 +102,7 @@ ifndef::qs[]
 endif::[]
 
 .Procedure
-. On the command line, set the Kafka instance bootstrap server, client credentials, and consumer group ID as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
+. On the command line, set the Kafka instance bootstrap server, client credentials as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
 +
 --
 ifdef::qs[]

--- a/quarkus/README.adoc
+++ b/quarkus/README.adoc
@@ -102,7 +102,7 @@ ifndef::qs[]
 endif::[]
 
 .Procedure
-. On the command line, set the Kafka instance bootstrap server, client credentials as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
+. On the command line, set the Kafka instance bootstrap server and client credentials as environment variables to be used by Quarkus or other applications. Replace the values with your own server and credential information.
 +
 --
 ifdef::qs[]


### PR DESCRIPTION
fixes #291 

GROUP_ID env variable is not used in quarkus. It is also not documented causing some issues with completing guide.