### PR TITLE
docs: scripts and kafkacat quickstarts updates

### DIFF
--- a/getting-started/README.adoc
+++ b/getting-started/README.adoc
@@ -212,6 +212,8 @@ endif::[]
 ifdef::qs[]
 [#conclusion]
 Congratulations! You successfully completed the {product} Getting Started quick start, and are now ready to use the service.
+
+You can use Kafka scripts to check that you can connect with your Kafka instance.
 endif::[]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/kafka-bin-scripts/README.adoc
+++ b/kafka-bin-scripts/README.adoc
@@ -35,7 +35,7 @@ END GENERATED ATTRIBUTES
 ////
 
 [id="chap-kafka-bin-scripts"]
-= Using Kafka bin scripts with {product-long}
+= Configuring and connecting Kafka scripts with {product-long}
 ifdef::context[:parent-context: {context}]
 :context: using-kafka-bin-scripts
 
@@ -46,59 +46,31 @@ ifdef::context[:parent-context: {context}]
 
 // Purpose statement for the assembly
 [role="_abstract"]
-As a developer of applications and services, you can use the Kafka bin scripts to manage your Kafka instances in {product-long}.
-The Kafka bin scripts are a set of shell scripts that are included with the Apache Kafka distribution.
-With these bin scripts, you can produce and consume messages for your Kafka instances.
+As a developer of applications and services, you can use Kafka scripts to manage your Kafka instances in {product-long}.
+The Kafka scripts are a set of shell scripts that are included with the https://kafka.apache.org/downloads[Apache Kafka distribution^].
+With these scripts, you can produce and consume messages for your Kafka instances.
 
-NOTE: The command examples in this quick start demonstrate how to use the Kafka bin scripts on Linux and macOS. If you're using Windows, use the Windows versions of the bin scripts. For example, instead of the `__<Kafka-distribution-dir>__/bin/kafka-console-producer.sh` script, use the `__<Kafka-distribution-dir>__\bin\windows\kafka-console-producer.bat` script.
+ifndef::community[]
+NOTE: The Kafka scripts are part of the open source community version of Apache Kafka. The scripts are not a part of {product} and are therefore not supported by Red Hat.
+endif::[]
+
+When you download and extract the Apache Kafka distribution, the `bin/` directory (or the `bin\windows\` directory if you're using Windows) of the distribution contains a set of shell scripts that enable you to interact with your Kafka instance.
+With the scripts, you can produce and consume messages, and perform various operations against the Kafka APIs to administer topics, consumer groups, and other resources.
+
+NOTE: The command examples in this quick start demonstrate how to use the Kafka scripts on Linux and macOS. If you're using Windows, use the Windows versions of the scripts. For example, instead of the `__<Kafka-distribution-dir>__/bin/kafka-console-producer.sh` script, use the `__<Kafka-distribution-dir>__\bin\windows\kafka-console-producer.bat` script.
 
 .Prerequisites
 ifndef::community[]
 * You have a Red Hat account.
 endif::[]
 * You have a running Kafka instance in {product}.
+* You have downloaded the latest binary version of the https://kafka.apache.org/downloads[Apache Kafka distribution^].
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
 * For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
 
-ifdef::qs[]
-[#description]
-Learn how to use Kafka bin scripts to interact with a Kafka instance in {product-long}.
+You can check the version number of the `kafka-console-producer` script to verify that the expected Kafka version is downloaded.
 
-[#introduction]
-Welcome to the quick start for {product-long} with Kafka bin scripts. In this quick start, you'll learn how to use the Kafka bin scripts to produce and consume messages for your Kafka instances in {product}.
-endif::[]
-
-[id="proc-downloading-kafka-bin-scripts_{context}"]
-== Downloading the Kafka bin scripts
-
-The Kafka bin scripts are the binary scripts that are provided in the https://kafka.apache.org/downloads[Apache Kafka distribution^]. When you extract the Apache Kafka distribution, the `bin/` directory (or the `bin\windows\` directory if you're using Windows) of the distribution contains a set of shell scripts that enable you to interact with your Kafka instance. With the bin scripts, you can produce and consume messages, and perform various operations against the Kafka APIs to administer topics, consumer groups, and other resources.
-
-ifndef::community[]
-NOTE: The Kafka bin scripts are part of the open source community version of Apache Kafka. The bin scripts are not a part of {product} and are therefore not supported by Red Hat.
-endif::[]
-
-.Procedure
-. In a web browser, go to the Kafka https://kafka.apache.org/downloads[Download^] page and download the latest binary version of Apache Kafka.
-. Extract the downloaded archive and navigate to the `bin/` directory.
-+
---
-This example extracts the archive and then changes to the `bin/` directory.
-
-.Extracting the Kafka archive and navigating to the `bin/` directory
-[source]
-----
-$ tar -xzf kafka_2.13-2.7.0.tgz
-$ cd kafka_2.13-2.7.0/bin
-----
-
-The `bin/` directory contains the Kafka bin scripts.
---
-
-. Review the scripts in the `bin/` directory and verify that you have the `kafka-console-producer` and `kafka-console-consumer` scripts.
-
-. Check the version number of the `kafka-console-producer` script to verify that the scripts were downloaded correctly.
-+
-.Verifying Kafka bin scripts
+.Verifying Kafka scripts
 [source]
 ----
 $ ./kafka-console-producer.sh --version
@@ -106,14 +78,17 @@ $ ./kafka-console-producer.sh --version
 ----
 
 ifdef::qs[]
-.Verification
-. Were the Kafka bin scripts installed successfully?
-endif::qs[]
+[#description]
+Learn how to use Kafka scripts to interact with a Kafka instance in {product-long}.
+
+[#introduction]
+Welcome to the quick start for {product-long} with Kafka scripts. In this quick start, you'll learn how to use the Kafka scripts to produce and consume messages for your Kafka instances in {product}.
+endif::[]
 
 [id="proc-configuring-kafka-bin-scripts_{context}"]
-== Configuring the Kafka bin scripts to connect to a Kafka instance
+== Configuring the Kafka scripts to connect to a Kafka instance
 
-To enable the Kafka bin scripts to access a Kafka instance, you must configure the connection using the generated credentials for your {product} service account. For the Kafka bin scripts, you will create a configuration file that defines these values.
+To enable the Kafka scripts to access a Kafka instance, you must configure the connection using the generated credentials for your {product} service account. For the Kafka scripts, you will create a configuration file that defines these values.
 
 .Prerequisites
 ifndef::qs[]
@@ -126,14 +101,12 @@ endif::[]
 
 . Create a file called `{property-file-name}`.
 
-. In the `{property-file-name}` file, set the Kafka instance client credentials and consumer group ID. Replace the values with your own server and credential information.
+. In the `{property-file-name}` file, set the SASL connection mechanism and the Kafka instance client credentials. Replace the values with your own credential information.
 +
 --
 ifdef::qs[]
 The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots), clicking *Connection*, and creating the service account.
 endif::[]
-
-All consumers with the same group ID belong to the consumer group with that ID.
 
 .Setting server and credential values
 [source,subs="+quotes"]
@@ -143,23 +116,22 @@ security.protocol=SASL_SSL
 
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
   username="__<client_id>__" \
-  password="__<client_secret>__" \
-  group.id="__<consumer_group_id>__";
+  password="__<client_secret>__" ;
 ----
 
-NOTE: {product} also supports the SASL/OAUTHBEARER mechanism for authentication, which is the recommended authentication mechanism to use. However, the Kafka bin scripts do not yet fully support OAUTHBEARER, so this example uses SASL/PLAIN.
+NOTE: {product} also supports the SASL/OAUTHBEARER mechanism for authentication, which is the recommended authentication mechanism to use. However, the Kafka scripts do not yet fully support OAUTHBEARER, so this example uses SASL/PLAIN.
 
 --
 . Save the file. You will use it in the next task to connect to your Kafka instance and produce messages.
 
 [id="proc-producing-messages-kafka-bin-scripts_{context}"]
-== Producing messages using Kafka bin scripts
+== Producing messages using Kafka scripts
 
 You can use the `kafka-console-producer` script to produce messages to Kafka topics.
 
 .Prerequisites
 
-* The Kafka bin scripts are downloaded.
+* You have checked that the `kafka-console-producer` and `kafka-topics` scripts are in the `bin/` directory of your Kafka download.
 * You have a running Kafka instance in {product}.
 ifndef::qs[]
 * You have the bootstrap server endpoint for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots) and clicking *Connection*.
@@ -217,13 +189,14 @@ ifndef::qs[]
 endif::[]
 
 [id="proc-consuming-messages-kafka-bin-scripts_{context}"]
-== Consuming messages using Kafka bin scripts
+== Consuming messages using Kafka scripts
 
 You can use the `kafka-console-consumer` script to consume messages from Kafka topics. This example consumes the messages that you sent previously with the producer that you created with the `kafka-console-producer` script.
 
 .Prerequisites
 
 * You used the `kafka-console-producer` script to produce example messages to a topic.
+* You have checked that the `kafka-console-consumer` script is in the `bin/` directory of your Kafka download.
 
 .Procedure
 
@@ -258,7 +231,7 @@ endif::[]
 
 ifdef::qs[]
 [#conclusion]
-Congratulations! You successfully completed the {product} Kafka bin scripts quick start, and are now ready to produce and consume messages in the service.
+Congratulations! You successfully completed the {product} Kafka scripts quick start, and are now ready to produce and consume messages in the service.
 endif::[]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/kafka-bin-scripts/README.adoc
+++ b/kafka-bin-scripts/README.adoc
@@ -64,12 +64,10 @@ ifndef::community[]
 * You have a Red Hat account.
 endif::[]
 * You have a running Kafka instance in {product}.
-* You have downloaded the latest binary version of the https://kafka.apache.org/downloads[Apache Kafka distribution^].
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
 * For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
-
-You can check the version number of the `kafka-console-producer` script to verify that the expected Kafka version is downloaded.
-
+* You have downloaded the latest supported binary version of the https://kafka.apache.org/downloads[Apache Kafka distribution^].
++
 .Verifying Kafka scripts
 [source]
 ----
@@ -131,7 +129,6 @@ You can use the `kafka-console-producer` script to produce messages to Kafka top
 
 .Prerequisites
 
-* You have checked that the `kafka-console-producer` and `kafka-topics` scripts are in the `bin/` directory of your Kafka download.
 * You have a running Kafka instance in {product}.
 ifndef::qs[]
 * You have the bootstrap server endpoint for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots) and clicking *Connection*.
@@ -196,7 +193,6 @@ You can use the `kafka-console-consumer` script to consume messages from Kafka t
 .Prerequisites
 
 * You used the `kafka-console-producer` script to produce example messages to a topic.
-* You have checked that the `kafka-console-consumer` script is in the `bin/` directory of your Kafka download.
 
 .Procedure
 

--- a/kafka-bin-scripts/quickstart.yml
+++ b/kafka-bin-scripts/quickstart.yml
@@ -15,7 +15,7 @@ spec:
   description: !snippet README.adoc#description
   prerequisites:
     - A running Kafka instance (see the Getting Started quick start)
-    - The latest binary version of the Apache Kafka distribution
+    - The latest supported binary version of the Apache Kafka distribution
     - A command-line terminal application
     - JDK 11 or later
     - For Windows, the latest version of Oracle JDK

--- a/kafka-bin-scripts/quickstart.yml
+++ b/kafka-bin-scripts/quickstart.yml
@@ -21,7 +21,6 @@ spec:
     - For Windows, the latest version of Oracle JDK
   introduction: !snippet README.adoc#introduction
   tasks:
-    - !snippet/proc README.adoc#proc-downloading-kafka-bin-scripts
     - !snippet/proc README.adoc#proc-configuring-kafka-bin-scripts
     - !snippet/proc README.adoc#proc-producing-messages-kafka-bin-scripts
     - !snippet/proc README.adoc#proc-consuming-messages-kafka-bin-scripts

--- a/kafka-bin-scripts/quickstart.yml
+++ b/kafka-bin-scripts/quickstart.yml
@@ -15,6 +15,7 @@ spec:
   description: !snippet README.adoc#description
   prerequisites:
     - A running Kafka instance (see the Getting Started quick start)
+    - The latest binary version of the Apache Kafka distribution
     - A command-line terminal application
     - JDK 11 or later
     - For Windows, the latest version of Oracle JDK

--- a/kafkacat/README.adoc
+++ b/kafkacat/README.adoc
@@ -63,12 +63,10 @@ ifndef::community[]
 endif::[]
 //* You have a subscription to {product-long}. For more information about signing up, see *<@SME: Where to link?>*.
 * You have a running Kafka instance in {product}.
-* You have installed the latest version of https://github.com/edenhill/kafkacat[Kafkacat^] for your operating system.
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
 * For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
-
-You can check the version number of Kafkacat to verify that the expected version is installed.
-
+* You have installed the latest supported version of https://github.com/edenhill/kafkacat[Kafkacat^] for your operating system.
++
 .Verifying Kafkacat installation
 [source]
 ----

--- a/kafkacat/README.adoc
+++ b/kafkacat/README.adoc
@@ -35,7 +35,7 @@ END GENERATED ATTRIBUTES
 ////
 
 [id="chap-using-kafkacat"]
-= Using Kafkacat with Kafka instances in {product-long}
+= Configuring and connecting Kafkacat with Kafka instances in {product-long}
 ifdef::context[:parent-context: {context}]
 :context: using-kafkacat
 
@@ -46,7 +46,16 @@ ifdef::context[:parent-context: {context}]
 
 // Purpose statement for the assembly
 [role="_abstract"]
-As a developer of applications and services, you can use https://github.com/edenhill/kafkacat[Kafkacat^] to test and debug your Kafka instances in {product-long}. Kafkacat is a command-line utility for messaging in Apache Kafka 0.8 and later. With Kafkacat, you can produce and consume messages for your Kafka instances directly from the command line, and list topic and partition information for your Kafka instances.
+As a developer of applications and services, you can use https://github.com/edenhill/kafkacat[Kafkacat^] to test and debug your Kafka instances in {product-long}.
+Kafkacat is a command-line utility for messaging in Apache Kafka 0.8 and later.
+With Kafkacat, you can produce and consume messages for your Kafka instances directly from the command line,
+and list topic and partition information for your Kafka instances.
+
+ifndef::community[]
+NOTE: Kafkacat is an open source community tool. Kafkacat is not a part of {product} and is therefore not supported by Red Hat.
+endif::[]
+
+You can install and use Kafkacat to test and debug your Kafka instances in {product}.
 
 .Prerequisites
 ifndef::community[]
@@ -54,32 +63,12 @@ ifndef::community[]
 endif::[]
 //* You have a subscription to {product-long}. For more information about signing up, see *<@SME: Where to link?>*.
 * You have a running Kafka instance in {product}.
+* You have installed the latest version of https://github.com/edenhill/kafkacat[Kafkacat^] for your operating system.
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
 * For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
 
-// Condition out QS-only content so that it doesn't appear in docs.
-// All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.
-ifdef::qs[]
-[#description]
-Learn how to use Kafkacat to interact with a Kafka instance in {product-long}.
+You can check the version number of Kafkacat to verify that the expected version is installed.
 
-[#introduction]
-Welcome to the quick start for {product-long} with Kafkacat. In this quick start, you'll learn how to use https://github.com/edenhill/kafkacat[Kafkacat^] to produce and consume messages for your Kafka instances in {product}.
-endif::[]
-
-[id="proc-installing-kafkacat_{context}"]
-== Installing and verifying Kafkacat
-
-https://github.com/edenhill/kafkacat[Kafkacat^] is a command-line utility for messaging in Apache Kafka 0.8 and later. You can install and use Kafkacat to test and debug your Kafka instances in {product}. With Kafkacat, you can produce and consume messages for your Kafka instances directly from the command line, and list topic and partition information for your Kafka instances.
-
-ifndef::community[]
-NOTE: Kafkacat is an open source community tool. Kafkacat is not a part of {product} and is therefore not supported by Red Hat.
-endif::[]
-
-.Procedure
-. In a web browser, go to the https://github.com/edenhill/kafkacat[Kafkacat^] repository in GitHub and follow the installation instructions for your operating system.
-. Verify that the expected version was installed:
-+
 .Verifying Kafkacat installation
 [source]
 ----
@@ -91,9 +80,14 @@ Copyright (c) 2014-2019, Magnus Edenhill
 Version 1.6.0 (JSON, Avro, Transactions, librdkafka 1.6.1 builtin.features=gzip,snappy,ssl,sasl,regex,lz4,sasl_gssapi,sasl_plain,sasl_scram,plugins,zstd,sasl_oauthbearer)
 ----
 
+// Condition out QS-only content so that it doesn't appear in docs.
+// All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.
 ifdef::qs[]
-.Verification
-* Was Kafkacat installed successfully?
+[#description]
+Learn how to use Kafkacat to interact with a Kafka instance in {product-long}.
+
+[#introduction]
+Welcome to the quick start for {product-long} with Kafkacat. In this quick start, you'll learn how to use https://github.com/edenhill/kafkacat[Kafkacat^] to produce and consume messages for your Kafka instances in {product}.
 endif::[]
 
 [id="proc-configuring-kafkacat_{context}"]
@@ -111,14 +105,12 @@ ifndef::qs[]
 endif::[]
 
 .Procedure
-* On the command line, set the Kafka instance bootstrap server, client credentials, and consumer group ID as environment variables to be used by Kafkacat or other applications. Replace the values with your own server and credential information.
+* On the command line, set the Kafka instance bootstrap server and client credentials as environment variables to be used by Kafkacat or other applications. Replace the values with your own server and credential information.
 +
 --
 ifdef::qs[]
 The `<bootstrap_server>` is the bootstrap server endpoint for your service account. The `<client_id>` and `<client_secret>` are the generated credentials for your service account. You copied this information previously for the Kafka instance in {product} by selecting the options menu (three vertical dots) and clicking *Connection*.
 endif::[]
-
-All consumers with the same group ID belong to the consumer group with that ID.
 
 .Setting environment variables for server and credentials
 [source,subs="+quotes"]
@@ -126,7 +118,6 @@ All consumers with the same group ID belong to the consumer group with that ID.
 $ export BOOTSTRAP_SERVER=__<bootstrap_server>__
 $ export USER=__<client_id>__
 $ export PASSWORD=__<client_secret>__
-$ export GROUP_ID=__<group_id>__
 ----
 --
 

--- a/kafkacat/quickstart.yml
+++ b/kafkacat/quickstart.yml
@@ -15,6 +15,7 @@ spec:
   description: !snippet README.adoc#description
   prerequisites:
     - A running Kafka instance (see the Getting Started quick start)
+    - The latest version of Kafkacat for your operating system
     - A command-line terminal application
     - JDK 11 or later
     - For Windows, the latest version of Oracle JDK

--- a/kafkacat/quickstart.yml
+++ b/kafkacat/quickstart.yml
@@ -21,7 +21,6 @@ spec:
     - For Windows, the latest version of Oracle JDK
   introduction: !snippet README.adoc#introduction
   tasks:
-    - !snippet/proc README.adoc#proc-installing-kafkacat
     - !snippet/proc README.adoc#proc-configuring-kafkacat
     - !snippet/proc README.adoc#proc-producing-messages-kafkacat
     - !snippet/proc README.adoc#proc-consuming-messages-kafkacat

--- a/kafkacat/quickstart.yml
+++ b/kafkacat/quickstart.yml
@@ -15,7 +15,7 @@ spec:
   description: !snippet README.adoc#description
   prerequisites:
     - A running Kafka instance (see the Getting Started quick start)
-    - The latest version of Kafkacat for your operating system
+    - The latest supported version of Kafkacat for your operating system
     - A command-line terminal application
     - JDK 11 or later
     - For Windows, the latest version of Oracle JDK


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

This PR updates the _Kafka scripts_ and _Kafkacat_ quick starts. 

- Changes the titles to _Configuring and connecting..._ rather than _Using..._ 
- Replaces _bin scripts_ with _scripts_  
- Removes the download/install step, which becomes a general prereq. Other detail moved to other sections of each quick start
- Adds a line about using the Kafka scripts to check a new Kafka instance to _Getting Started_
- Removes group Id config (not currently working)

NOTE
- The PR doesn't change Kafkacat to kcat (pending a decision on that)
- The version check (`-version` and `-V`) is moved to a portal-only section

Details: [MGDSTRM-5099](https://issues.redhat.com/browse/MGDSTRM-5099)

PORTAL DOC
- [Kafkacat quick start](http://file.emea.redhat.com/pmellor/docs/managed-kafka-drafts/kafkacat-quickstart.html)
- [Kafka scripts quick start](http://file.emea.redhat.com/pmellor/docs/managed-kafka-drafts/kafka-scripts-quickstart.html)
