### PR TITLE
Fix ./kafka-console-consumer.sh cmd line

### DIFF
--- a/consumer-configuration/README.adoc
+++ b/consumer-configuration/README.adoc
@@ -132,7 +132,7 @@ h|Supported values
 If you're using Kafka scripts to consume messages, you can use the `kafka-console-consumer.sh` tool to create a group ID:
 [source,subs="+quotes,+attributes"]
 ----
-./kafka-console-consumer.sh --bootstrap-server __<bootstrap_server>__ --consumer-config __<authentication_properties>__ --topic test-topic --group my-consumer-group
+./kafka-console-consumer.sh --bootstrap-server __<bootstrap_server>__ --consumer.config __<authentication_properties>__ --topic test-topic --group my-consumer-group
 ----
 
 The new consumer group is named `my-consumer-group`.


### PR DESCRIPTION
Tested with Kafka 2.8.1 and the correct option is:
```
--consumer.config <String: config file>  Consumer config properties file. Note  
                                           that [consumer-property] takes       
                                           precedence over this config.    
```