### PR TITLE
Fix the pom.xml files for quarkus-service-registry-quickstart

### DIFF
--- a/code-examples/quarkus-service-registry-quickstart/consumer/pom.xml
+++ b/code-examples/quarkus-service-registry-quickstart/consumer/pom.xml
@@ -3,13 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-registry-kafka-quickstart</artifactId>
+        <artifactId>quarkus-service-registry-quickstart</artifactId>
         <groupId>org.example</groupId>
         <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-registry-kafka-quickstart-producer</artifactId>
+    <artifactId>quarkus-service-registry-quickstart-consumer</artifactId>
 
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>

--- a/code-examples/quarkus-service-registry-quickstart/pom.xml
+++ b/code-examples/quarkus-service-registry-quickstart/pom.xml
@@ -8,10 +8,10 @@
     <artifactId>quarkus-service-registry-quickstart</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
+
     <modules>
         <module>producer</module>
         <module>consumer</module>
     </modules>
-
 
 </project>

--- a/code-examples/quarkus-service-registry-quickstart/producer/pom.xml
+++ b/code-examples/quarkus-service-registry-quickstart/producer/pom.xml
@@ -6,10 +6,11 @@
         <artifactId>quarkus-service-registry-quickstart</artifactId>
         <groupId>org.example</groupId>
         <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-service-registry-quickstart-processor</artifactId>
+    <artifactId>quarkus-service-registry-quickstart-producer</artifactId>
 
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>


### PR DESCRIPTION
There were some issues with the quarkus-service-registry-quickstart pom.xml files that have been corrected.  The quickstart should build now.