### PR TITLE
Fix Kafka topic create options for Kafka 3

### DIFF
--- a/kafka-bin-scripts/README.adoc
+++ b/kafka-bin-scripts/README.adoc
@@ -80,7 +80,7 @@ endif::[]
 [source]
 ----
 $ ./kafka-console-producer.sh --version
-2.7.0 (Commit:448719dc99a19793)
+3.0.0 (Commit:8cb0a5e9d3441962)
 ----
 
 ifdef::qs[]
@@ -158,7 +158,7 @@ endif::[]
 .Using the `kafka-topics` script to create a Kafka topic
 [source,subs="+quotes,+attributes"]
 ----
-$ ./kafka-topics.sh --create --topic my-other-topic --bootstrap-server __<bootstrap_server>__ --command-config ../config/{property-file-name}
+$ ./kafka-topics.sh --create --topic my-other-topic --partitions 1 --replication-factor 3 --bootstrap-server __<bootstrap_server>__ --command-config ../config/{property-file-name}
 Created topic my-other-topic.
 ----
 --


### PR DESCRIPTION
I tried the quickstart using Kafka 3.0.0 scripts which is the last version that can be downloaded and to create a topic the `--partitions` and `--replication-factor` options are mandatory