### PR TITLE
Update CLI install guide do use downstream

### DIFF
--- a/rhoas-cli/README.adoc
+++ b/rhoas-cli/README.adoc
@@ -73,68 +73,40 @@ NOTE: The `rhoas` link:https://github.com/redhat-developer/app-services-cli/rele
 [discrete,id="installing-rhoas-cli-linux_{context}"]
 === Installing the rhoas CLI on Linux
 
-If you are using Linux, you can install `rhoas` by either using the installation script, or the RPM.
-The installation script installs the latest version of `rhoas` by default.
-
-[discrete,id="installation-script_{context}"]
-==== Installation script
-
 .Procedure
 
-. Review the https://github.com/redhat-developer/app-services-cli/blob/main/scripts/install.sh[`install.sh` installation script^].
+. Navigate to the https://developers.redhat.com/products/red-hat-openshift-streams-for-apache-kafka/overview[Red Hat OpenShift Streams for Apache Kafka] page on the Red Hat Developer Portal.
 
-. Run the `install.sh` script:
+. Click https://developers.redhat.com/products/red-hat-openshift-streams-for-apache-kafka/download[*Install/specifics*] and scroll to the bottom of the page to the *All Downloads* section.
+
+. In the *RHOAS CLI* downloads table, in the Linux row, click the *Download* button to download the `rhoas` .zip file.
+
+. Extract the `rhoas` binary:
 +
 --
 [source,shell]
 ----
-$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash
+unzip rhoas-${version}-linux.zip
 ----
 
-The `rhoas` CLI is installed in `$HOME/.local/bin`.
+An open source license and README file are also included in the .zip file.
 --
 
-. Verify that the `rhoas` installation directory is on your `$PATH`.
+. For `rhoas` to be executable from any directory you must place it onto your system PATH. To view which directories are on your PATH, run the following:
 +
 --
-To check your `$PATH`, run the following command:
-
 [source,shell]
 ----
-$ echo $PATH
+echo $PATH
 ----
 --
 
-. Check the `rhoas` version to verify that the CLI is installed.
+. Move the `rhoas` executable to your preferred PATH location:
 +
---
-This example shows that `rhoas` is installed:
-
 [source,shell]
 ----
-$ rhoas --version
+mv rhoas $HOME/.local/bin
 ----
---
-
-[discrete,id="rpm-installation_{context}"]
-==== RPM installation
-
-You can install `rhoas` as an RPM if you are using Red Hat Enterprise Linux (RHEL), Fedora, or CentOS.
-
-.Procedure
-
-. Navigate to the `rhoas` link:https://github.com/redhat-developer/app-services-cli/releases[Releases page^] and choose the version that you'd like to download.
-
-. Use `dnf`/`yum` to install the desired version of `rhoas`:
-+
---
-This example installs `rhoas`:
-
-[source,shell,subs="+quotes"]
-----
-$ sudo dnf install -y https://github.com/redhat-developer/app-services-cli/releases/download/v_<__version-num__>_/rhoas_<__version-num__>_linux_amd64.rpm
-----
---
 
 . Check the `rhoas` version to verify that the CLI is installed.
 +
@@ -152,29 +124,38 @@ $ rhoas --version
 
 .Procedure
 
-. Review the link:https://github.com/redhat-developer/app-services-cli/blob/main/scripts/install.sh[`install.sh` installation script^].
+. Navigate to the https://developers.redhat.com/products/red-hat-openshift-streams-for-apache-kafka/overview[Red Hat OpenShift Streams for Apache Kafka] page on the Red Hat Developer Portal.
 
-. Run the `install.sh` script:
+. Click https://developers.redhat.com/products/red-hat-openshift-streams-for-apache-kafka/download[*Install/specifics*] and scroll to the bottom of the page to the *All Downloads* section.
+
+. In the *RHOAS CLI* downloads table, in the macOS row, click the *Download* button to download the `rhoas` .zip file.
+
+. Extract the `rhoas` binary: 
 +
 --
 [source,shell]
 ----
-$ curl -o- https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/scripts/install.sh | bash
+unzip rhoas-${version}-darwin.zip
 ----
 
-The `rhoas` CLI is installed in `$HOME/bin`.
+An open source license and README file are also included in the .zip file.
 --
 
-. Verify that the `rhoas` installation directory is on your `$PATH`.
+. For `rhoas` to be executable from any directory you must place it onto your system PATH. To view which directories are on your PATH, run the following:
 +
 --
-To check your `$PATH`, run the following command:
-
 [source,shell]
 ----
-$ echo $PATH
+echo $PATH
 ----
 --
+
+. Move the `rhoas` executable to your preferred PATH location:
++
+[source,shell]
+----
+mv rhoas $HOME/bin
+----
 
 . Check the `rhoas` version to verify that the CLI is installed.
 +
@@ -192,9 +173,11 @@ $ rhoas --version
 
 .Procedure
 
-. Navigate to the `rhoas` link:https://github.com/redhat-developer/app-services-cli/releases[Releases page^].
+. Navigate to the https://developers.redhat.com/products/red-hat-openshift-streams-for-apache-kafka/overview[Red Hat OpenShift Streams for Apache Kafka] page on the Red Hat Developer Portal.
 
-. Download the latest `rhoas` .zip file.
+. Click https://developers.redhat.com/products/red-hat-openshift-streams-for-apache-kafka/download[*Install/specifics*] and scroll to the bottom of the page to the *All Downloads* section.
+
+. In the *RHOAS CLI* downloads table, in the Windows row, click the *Download* button to download the `rhoas` .zip file.
 
 . On your computer, create a `C:\rhoas` folder.
 
@@ -221,7 +204,7 @@ This example shows that `rhoas` is installed:
 
 [source,shell]
 ----
-$ rhoas --version
+rhoas --version
 ----
 --
 
@@ -350,8 +333,7 @@ In your terminal, the `rhoas login` command indicates that you are logged in:
 [source,shell]
 ----
 $ rhoas login
-Logging in...
-✔️ Logged in successfully
+⣟ Logging in...
 
 ✔️ You are now logged in as "user"
 ----


### PR DESCRIPTION
Originally created by @craicoverflow . To be applied when we are confident with our downstream release schedule