### PR TITLE
Upstream release process

### DIFF
--- a/.github/workflows/modular-docs-publish.yml
+++ b/.github/workflows/modular-docs-publish.yml
@@ -4,8 +4,9 @@ name: Modular docs publish
 
 on:
   push:
-    branches: [ main ]
-
+    tags:
+      - 'v*'
+    #branches: [main]
 jobs:
   build:
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -334,6 +334,8 @@ link: https://github.com/redhat-developer/app-services-guides/releases/new
 
 . Please provide tag name. For example v0.1.0
 . Please provide the same value for release title (v0.1.0)
+. Please click on "Autogenerate Release Notes" to generate release notes
+. Select Create to create release
 
 NOTE: CICD process will automatically synchronize changes with downstream on release
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -323,3 +323,17 @@ npm --prefix .build run generate:attributes
 NOTE: If you check in out of date attributes the build will fail
 . Having create the PR, automated tests will run. If they fail, use the error log to determine the problem, and fix it
 . Once your build is passing ask for review from a Subject Matter Expert (who will check for accuracy), a writer (who will check that the content is up to expected quality for substance, formatting, style, structure and consistency), and a developer who will ensure the steps covered by the quick start are the end to end test suite.
+
+== Releases
+
+Guides are released by creating tag in format vx.x.x - where x is number representing semver version. 
+Releases should be created at major milestones based on the documented features being already published and available to users.
+
+. Use following link to create new release
+link: https://github.com/redhat-developer/app-services-guides/releases/new
+
+. Please provide tag name. For example v0.1.0
+. Please provide the same value for release title (v0.1.0)
+
+NOTE: CICD process will automatically synchronize changes with downstream on release
+


### PR DESCRIPTION
Following number of issues related to the frequent updates of Guides and CLI we going to be moving to release on demand. 

When we want to perform release we need to create github tag as outlined in the procedure.