### PR TITLE
Bump to latest quickstarts version, add transform-adoc

### DIFF
--- a/.build/package.json
+++ b/.build/package.json
@@ -71,8 +71,9 @@
     "generate:modular-docs": "npm-run-all generate:modular-docs-sources generate:modular-docs-output"
   },
   "dependencies": {
-    "@patternfly/quickstarts": "1.2.2",
+    "@patternfly/quickstarts": "2.0.1",
     "@patternfly/react-core": "4.135.0",
+    "@patternfly/transform-adoc": "0.1.0",
     "@redhat-cloud-services/frontend-components-config": "4.3.5",
     "@rhoas/app-services-ui-shared": "0.12.2",
     "react": "17.0.2",

--- a/.build/package.json
+++ b/.build/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@patternfly/quickstarts": "2.0.1",
     "@patternfly/react-core": "4.135.0",
-    "@patternfly/transform-adoc": "0.1.0",
+    "@patternfly/transform-adoc": "0.1.1",
     "@redhat-cloud-services/frontend-components-config": "4.3.5",
     "@rhoas/app-services-ui-shared": "0.12.2",
     "react": "17.0.2",

--- a/.build/src/bootstrap.tsx
+++ b/.build/src/bootstrap.tsx
@@ -4,5 +4,6 @@ import { App } from './app';
 import '@patternfly/patternfly/patternfly.css';
 import '@patternfly/patternfly/patternfly-addons.css';
 import "@patternfly/quickstarts/dist/quickstarts.min.css";
+import "@patternfly/transform-adoc/dist/transform-adoc.css";
 
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/.build/utils/quickstart-adoc.js
+++ b/.build/utils/quickstart-adoc.js
@@ -2,10 +2,13 @@ const yaml = require("yaml");
 const path = require("path");
 const jp = require("jsonpath");
 const fs = require("fs-extra");
-const {JSDOM} = require("jsdom");
+const { JSDOM } = require("jsdom");
 const fetch = require('sync-fetch');
 const asciidoctor = require('asciidoctor')();
 const Ajv = require("ajv").default;
+
+const { addReactConverter } = require('@patternfly/transform-adoc');
+addReactConverter(asciidoctor);
 
 const pantheonBaseUrl = process.env.PANTHEON_URL || "https://pantheon.corp.redhat.com/api";
 const attributesFile = process.env.ATTRIBUTES_FILE || "../_artifacts/document-attributes.adoc";
@@ -14,7 +17,7 @@ const buildQuickStart = (content, filePath, basePath, asciidocOptions) => {
 
 
   const validateJSON = (instance, schemaPath) => {
-    const ajv =  new Ajv();
+    const ajv = new Ajv();
     const rawSchema = fs.readFileSync(schemaPath, "utf8").toString();
     const schema = JSON.parse(rawSchema);
     const validate = ajv.compile(schema);
@@ -127,7 +130,7 @@ const buildQuickStart = (content, filePath, basePath, asciidocOptions) => {
       type = mapping["type"];
       cssSelector = mapping["cssSelector"] || defaultCssSelector;
       pathExpression = mapping["jsonPathExpression"] || defaultPathExpression;
-    } else if (typeof mapping === "string"){
+    } else if (typeof mapping === "string") {
       if (mapping.startsWith("https")) {
         const parts = mapping.match(/https:\/\/.*\/api\/(\w*)\/.*\/([a-z0-9-]*)/);
         if (parts.length !== 3) {
@@ -177,7 +180,7 @@ const buildQuickStart = (content, filePath, basePath, asciidocOptions) => {
     flat.push(block);
     if (block.hasBlocks && block.hasBlocks()) {
       block.getBlocks().forEach(block => {
-          flat.push(...flattenBlocks(block));
+        flat.push(...flattenBlocks(block));
       });
     }
     return flat;
@@ -209,7 +212,7 @@ const buildQuickStart = (content, filePath, basePath, asciidocOptions) => {
   const titleTag = {
     identify: false,
     tag: '!snippet/title',
-    resolve: (doc, cst) => loadSnippet(cst.strValue, "!snippet/title", undefined,(block) => block.getTitle(), '$.*.title'),
+    resolve: (doc, cst) => loadSnippet(cst.strValue, "!snippet/title", undefined, (block) => block.getTitle(), '$.*.title'),
     stringify: () => ""
   };
 


### PR DESCRIPTION
This PR should accomplish
 - Bumping `@patternfly/quickstarts` package to latest version
   - Includes various design updates to QS, summary [here](https://docs.google.com/presentation/d/1TJwFdaSNdRdu-26Ua1m6VUzcx-Z-wwIO6NVGlx5Swtc/edit#slide=id.g10ad437fe89_0_17)
 - Including `@patternfly/transform-adoc` package which adds an intermediate rendering step to the `asciidoc` pipeline to render PFReact components instead of `asciidoc` generated HTML in certain cases
    - There is an instructional quick start here: https://quickstarts.netlify.app/?quickstart=mas-alert-note-prereq, rendered by this [asciidoc](https://github.com/patternfly/patternfly-quickstarts/blob/main/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/README.adoc)

The transform-adoc module was updated last week in response to two issues, one from from @bredamc, and one I added after another issue was raised by email:

https://github.com/patternfly/patternfly-quickstarts/issues/119
https://github.com/patternfly/patternfly-quickstarts/issues/105

Those fixes are incorporated into the version of `@patternfly/transform-adoc` included in this pull request.


