### PR TITLE
Rework command output in CLI guides

### DIFF
--- a/rhoas-cli-kafka/README.adoc
+++ b/rhoas-cli-kafka/README.adoc
@@ -86,15 +86,18 @@ A Kafka instance includes a Kafka cluster, bootstrap server, and other required 
 
 .Procedure
 
-. Enter the following command to create a Kafka instance with default values.
+. Create a Kafka instance with default values.
 +
 --
 This example creates a Kafka instance called `my-kafka`.
 
-.Creating a Kafka instance
 [source,shell]
 ----
 $ rhoas kafka create --name my-kafka
+----
+
+.Example output
+----
 {
   "cloud_provider": "aws",
   "created_at": "2021-03-17T18:33:50.000799005Z",
@@ -122,21 +125,24 @@ You will be prompted to enter the `Name`, `Cloud Provider`, and `Cloud Region` f
 . Enter the following command to verify that the Kafka instance is ready to use.
 +
 --
-This command shows that the Kafka instance is ready to use,
-because the `Status` field is `ready`.
-
-.Reviewing details of a Kafka instance
 [source,shell]
 ----
 $ rhoas status kafka
-
-  Kafka
-  -----------------------------------------------------------------------------------
-  ID:                     1ptdfZRHmLKwqW6A3YKM2MawgDh
-  Name:                   my-kafka
-  Status:                 ready
-  Bootstrap URL:          my-kafka--ptdfzrhmlkwqw-a-ykm-mawgdh.kafka.devshift.org:443
 ----
+
+.Example output
+----
+
+Kafka
+-----------------------------------------------------------------------------------
+ID:                     1ptdfZRHmLKwqW6A3YKM2MawgDh
+Name:                   my-kafka
+Status:                 ready
+Bootstrap URL:          my-kafka--ptdfzrhmlkwqw-a-ykm-mawgdh.kafka.devshift.org:443
+----
+
+The command shows that the Kafka instance is ready to use,
+because the `Status` field is `ready`.
 
 [NOTE]
 ====
@@ -150,7 +156,8 @@ you can switch to a different instance by using the `rhoas kafka use` command.
 == Creating a service account
 
 [role="_abstract"]
-To connect your applications or services to a Kafka instance, you must first create a service account with credentials.
+To connect your applications or services to a Kafka instance,
+you must first create a service account with credentials.
 The credentials are exported to a file on your computer,
 which you can use to authenticate your application with your Kafka instance.
 
@@ -160,16 +167,18 @@ which you can use to authenticate your application with your Kafka instance.
 
 .Procedure
 
-. Enter the following command to create a service account.
+. Create a service account.
 +
 --
 This example creates a service account and saves the credentials in a JSON file.
 
-.Creating a service account
 [source,shell]
 ----
 $ rhoas service-account create --file-format json --short-description="rhoas-service-account"
+----
 
+.Example output
+----
 ✔️ Service account created successfully with ID "04ba07d6-b08c-45fb-af53-3522c1b4c32f".
 ✔️ Credentials saved to /home/developer/my-project/credentials.json
 ----
@@ -187,18 +196,21 @@ For more information, see the `rhoas service-account create` command help.
 view the `credentials.json` file that you created.
 +
 --
-.Verifying service account credentials
 [source,shell]
 ----
 $ cat credentials.json
+----
+
+.Example output
+----
 {
 	"clientID":"srvc-acct-8c95ca5e1225-94a-41f1-ab97-aacf3df1",
 	"clientSecret":"facf3df1-ab97-2253-aa87-ab97",
         "oauthTokenUrl": "https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token"
 }
 ----
-You'll use these credentials and the bootstrap server URL to connect your applications and services to your Kafka instance.
 
+You'll use these credentials and the bootstrap server URL to connect your applications and services to your Kafka instance.
 --
 
 . Set the permissions for your service account to access the Kafka instance resources.
@@ -206,12 +218,14 @@ You'll use these credentials and the bootstrap server URL to connect your applic
 This example allows applications to produce and consume messages from topics starting with a specified prefix that belong to any consumer group.
 +
 --
-.Assigning access permissions to a service account
 [source,shell]
 ----
 $ rhoas kafka acl grant-access --consumer --producer \
     --service-account srvc-acct-8c95ca5e1225-94a-41f1-ab97-aacf3df1 --topic-prefix myapp  --group all
+----
 
+.Example output
+----
 The following ACL rules are to be created:
 
   PRINCIPAL (7)                                   PERMISSION   OPERATION   DESCRIPTION
@@ -243,13 +257,6 @@ After creating a Kafka instance, you can create Kafka topics to start producing 
 [NOTE]
 ====
 You can use `rhoas kafka use` to switch to a specific Kafka instance.
-
-.Selecting a Kafka instance to use
-[source,shell]
-----
-$ rhoas kafka use --name my-kafka
-Kafka instance "my-kafka" has been set as the current instance.
-----
 ====
 
 .Procedure
@@ -259,10 +266,13 @@ Kafka instance "my-kafka" has been set as the current instance.
 --
 This example creates the `my-topic` Kafka topic.
 
-.Creating a Kafka topic with default values
 [source,shell]
 ----
 $ rhoas kafka topic create --name my-topic
+----
+
+.Example output
+----
 Topic "my-topic" created in Kafka instance "my-kafka":
 {
     "config": [

--- a/rhoas-cli-service-registry/README.adoc
+++ b/rhoas-cli-service-registry/README.adoc
@@ -97,6 +97,10 @@ This example creates a {registry} instance called `my-registry`.
 ----
 $ rhoas service-registry create --name my-registry
 Creating {registry} instance with name: my-registry
+----
+
+.Example output
+----
 ✔️ Successfully created {registry} instance
 {
   "browserUrl": "https://console.redhat.com/beta/application-services/service-registry/t/63620903-4a29-4ba4-8229-7ab793bf73f3",
@@ -120,23 +124,27 @@ You are prompted to enter the `Name` for the {registry} instance.
 ====
 --
 
-. Enter the following command to verify that the {registry} instance is ready to use.
+. Verify that the {registry} instance is ready to use.
 +
 --
 This command shows that the {registry} instance is ready to use,
 because the `Status` field is `ready`.
 
 .Reviewing details of a {registry} instance
-[source,shell,subs="attributes"]
+[source,shell]
 ----
 $ rhoas status service-registry
+----
 
-  {registry}
-  -----------------------------------------------------------
-  ID:                    63620903-4a29-4ba4-8229-7ab793bf73f3
-  Name:                  my-registry
-  Status:                ready
-  Registry URL:          https://service-registry-service-registry-production.apps.app-sre-prod-04.i5h0.p1.openshiftapps.com/t/63620903-4a29-4ba4-8229-7ab793bf73f3
+.Example output
+[subs="attributes"]
+----
+{registry}
+-----------------------------------------------------------
+ID:                    63620903-4a29-4ba4-8229-7ab793bf73f3
+Name:                  my-registry
+Status:                ready
+Registry URL:          https://service-registry-service-registry-production.apps.app-sre-prod-04.i5h0.p1.openshiftapps.com/t/63620903-4a29-4ba4-8229-7ab793bf73f3
 ----
 
 [NOTE]
@@ -161,15 +169,20 @@ which you can use to authenticate your application with your {registry} instance
 
 .Procedure
 
-. Enter the following command to create a service account.
+. Create a service account.
 +
 --
 This example creates a service account and saves the credentials in a JSON file.
 
 .Creating a service account
-[source,shell,subs="attributes"]
+[source,shell]
 ----
 $ rhoas service-account create --short-description="rhoas-service-account" --file-format json
+----
+
+.Example output
+[subs="attributes"]
+----
 Creating service account
 ✔️ Service account created successfully with ID "04ba07d6-b08c-45fb-af53-3522c1b4c32f".
 ✔️ Credentials saved to /home/developer/my-project/credentials.json
@@ -201,12 +214,17 @@ view the `credentials.json` file that you created.
 [source,shell]
 ----
 $ cat credentials.json
+----
+
+.Example output
+----
 {
 	"clientID":"srvc-acct-8c95ca5e1225-94a-41f1-ab97-aacf3df1",
 	"clientSecret":"facf3df1-ab97-2253-aa87-ab97",
     "oauthTokenUrl": "https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token"
 }
 ----
+
 You'll use these credentials and the {registry} URL to connect your applications and services to your {registry} instance.
 
 [NOTE]
@@ -224,6 +242,10 @@ This example creates a role called `manager` for the service account.
 [source,shell]
 ----
 $ rhoas service-registry role add --role=manager --service-account=srvc-acct-8c95ca5e1225-94a-41f1-ab97-aacf3df1
+----
+
+.Example output
+----
 Creating new role for principal
 Role was successfully applied
 ----
@@ -243,13 +265,6 @@ Artifacts might include, for example, schemas that define the structure of Kafka
 [NOTE]
 ====
 You can use `rhoas service-registry use` to switch to a specific {registry} instance.
-
-.Selecting a {registry} instance to use
-[source,shell,subs="attributes"]
-----
-$ rhoas service-registry use --name=my-registry
-{registry} instance "my-registry" has been set as the current instance.
-----
 ====
 
 .Procedure
@@ -257,26 +272,27 @@ $ rhoas service-registry use --name=my-registry
 . Upload a {registry} artifact.
 +
 --
-This example uploads a {registry} artifact called `my-artifact` to the {registry} instance.
+This example uploads {registry} artifact content called `my-artifact` to the {registry} instance.
 The artifact is an Apache Kafka Avro schema in JSON format.
 
-.Uploading an artifact
+.Uploading artifact content
 [source,shell]
 ----
 $ wget https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/docs/resources/avro-userInfo.json
---2021-09-27 16:17:18--  https://raw.githubusercontent.com/redhat-developer/app-services-cli/main/docs/resources/avro-userInfo.json
-Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.110.133, 185.199.111.133, 185.199.108.133, ...
-Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.110.133|:443... connected.
-HTTP request sent, awaiting response... 200 OK
-Length: 732 [text/plain]
-Saving to: ‘avro-userInfo.json’
+----
+--
 
-avro-userInfo.json  100%[==================>]     732  --.-KB/s    in 0.001s
-
-2021-09-27 16:17:18 (746 KB/s) - ‘avro-userInfo.json’ saved [732/732]
-
-
+. Create the {registry} artifact from the Avro schema that you uploaded.
++
+--
+.Creating an artifact
+[source, shell]
+----
 $ rhoas service-registry artifact create --type=AVRO --artifact-id=my-artifact avro-userInfo.json
+----
+
+.Example output
+----
 Using default artifacts group.
 Opening file: avro-userInfo.json
 Artifact created
@@ -308,6 +324,10 @@ This example lists all artifacts belonging to the {registry} instance.
 [source,shell]
 ----
 $ rhoas service-registry artifact list
+----
+
+.Example output
+----
 Using default artifacts group.
 
   ID            NAME      CREATED ON                 CREATED BY   TYPE   STATE
@@ -323,6 +343,10 @@ Using default artifacts group.
 [source,shell]
 ----
 $ rhoas service-registry artifact versions --artifact-id=my-artifact
+----
+
+.Example output
+----
 {
   "count": 1,
   "versions": [
@@ -344,6 +368,10 @@ $ rhoas service-registry artifact versions --artifact-id=my-artifact
 [source,shell]
 ----
 $ rhoas service-registry artifact metadata-get --artifact-id=my-artifact
+----
+
+.Example output
+----
 Using default artifacts group.
 Fetching artifact metadata
 ✔️ Successfully fetched artifact metadata
@@ -449,9 +477,9 @@ $ rhoas service-registry artifact update --artifact-id=my-artifact my-artifact.j
 If you want to update the artifact from standard input,
 enter the following command:
 
-`$ rhoas service-registry artifact update --artifact-id=my_artifact`
+`rhoas service-registry artifact update --artifact-id=my_artifact`
 
-Paste the updated artifact content on the command line, and then press Ctrl+D to save.
+Paste the updated artifact content on the command line, and then press kbd:[Ctrl+D] to save.
 ====
 --
 
@@ -462,6 +490,10 @@ Paste the updated artifact content on the command line, and then press Ctrl+D to
 [source,shell]
 ----
 $ rhoas service-registry artifact metadata-get --artifact-id=my-artifact
+----
+
+.Example output
+----
 Using default artifacts group.
 Fetching artifact metadata
 ✔️ Successfully fetched artifact metadata

--- a/rhoas-cli/README.adoc
+++ b/rhoas-cli/README.adoc
@@ -98,25 +98,17 @@ The `rhoas` CLI is installed in `$HOME/.local/bin`.
 
 . Verify that the `rhoas` installation directory is on your `$PATH`.
 +
---
-To check your `$PATH`, run the following command:
-
 [source,shell]
 ----
 $ echo $PATH
 ----
---
 
 . Check the `rhoas` version to verify that the CLI is installed.
 +
---
-This example shows that `rhoas` is installed:
-
 [source,shell]
 ----
 $ rhoas --version
 ----
---
 
 [discrete,id="rpm-installation_{context}"]
 ==== RPM installation
@@ -140,14 +132,10 @@ $ sudo dnf install -y https://github.com/redhat-developer/app-services-cli/relea
 
 . Check the `rhoas` version to verify that the CLI is installed.
 +
---
-This example shows that `rhoas` is installed:
-
 [source,shell]
 ----
 $ rhoas --version
 ----
---
 
 [discrete,id="installing-rhoas-cli-macos_{context}"]
 === Installing the rhoas CLI on macOS
@@ -169,25 +157,17 @@ The `rhoas` CLI is installed in `$HOME/bin`.
 
 . Verify that the `rhoas` installation directory is on your `$PATH`.
 +
---
-To check your `$PATH`, run the following command:
-
 [source,shell]
 ----
 $ echo $PATH
 ----
---
 
 . Check the `rhoas` version to verify that the CLI is installed.
 +
---
-This example shows that `rhoas` is installed:
-
 [source,shell]
 ----
 $ rhoas --version
 ----
---
 
 [discrete,id="installing-rhoas-cli-windows_{context}"]
 === Installing the rhoas CLI on Windows
@@ -218,14 +198,10 @@ $ rhoas --version
 
 . Check the `rhoas` version to verify that the CLI is installed.
 +
---
-This example shows that `rhoas` is installed:
-
 [source,shell]
 ----
 $ rhoas --version
 ----
---
 
 [id="proc-configuring-rhoas_{context}"]
 == Configuring rhoas
@@ -347,11 +323,10 @@ You are redirected to your web browser at https://sso.redhat.com[^].
 --
 Welcome pages in the browser notify you that you have been logged in to `rhoas` successfully.
 
-In your terminal, the `rhoas login` command indicates that you are logged in:
+In your terminal, the `rhoas login` command indicates that you are logged in.
 
-[source,shell]
+.Example output
 ----
-$ rhoas login
 Logging in...
 ✔️ Logged in successfully
 
@@ -372,7 +347,6 @@ You can log out from the `rhoas` CLI by using the `rhoas logout` command.
 [source,shell]
 -----
 $ rhoas logout
-Successfully logged out
 -----
 
 [role="_additional-resources"]


### PR DESCRIPTION
Based on previous feedback, including the output of every command in the same block as the command itself can be confusing to users. For the CLI installation guide, and the RHOSAK and RHOSR getting started guides, I moved the command output to separate command blocks titled, "Example output".

@smccarthy-ie @bredamc The changes to "Getting started with the rhoas CLI for OpenShift Service Registry" were slightly more involved than the other guides. Please take a look and let me know what you think.