### PR TITLE
Clean up dirty URLs

### DIFF
--- a/docs/kafka/nodejs-kafka/README.adoc
+++ b/docs/kafka/nodejs-kafka/README.adoc
@@ -62,7 +62,7 @@ As a developer of applications and services, you can connect Node.js application
 ifndef::community[]
 * You have a Red Hat account.
 endif::[]
-* You have a Kafka instance in {product-kafka} and the instance is in the *Ready* state. To learn how to create a Kafka instance, see link:{base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}].
+* You have a Kafka instance in {product-kafka} and the instance is in the *Ready* state. To learn how to create a Kafka instance, see {base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}].
 * https://github.com/git-guides/[Git^] is installed.
 * You have an IDE such as https://www.jetbrains.com/idea/download/[IntelliJ IDEA^], https://www.eclipse.org/downloads/[Eclipse^], or https://code.visualstudio.com/Download[VSCode^].
 * https://nodejs.org/en/download/[Node.js 14^] is installed. The https://github.com/blizzard/node-rdkafka[node-rdkafka^] client can't run on later versions.

--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -62,10 +62,10 @@ You can also create Kafka topics to store data for producers and consumers.
 
 This guide describes how to get started quickly by doing the following:
 
-* link:{base-url}{rhoas-cli-getting-started-url-kafka}#proc-creating-kafka-instance-cli_getting-started-rhoas-kafka[Create a Kafka instance]
-* link:{base-url}{rhoas-cli-getting-started-url-kafka}#proc-creating-service-account-cli_getting-started-rhoas-kafka[Create a service account]
-* link:{base-url}{rhoas-cli-getting-started-url-kafka}#proc-creating-kafka-topic-cli_getting-started-rhoas-kafka[Create a Kafka topic]
-* link:{base-url}{rhoas-cli-getting-started-url-kafka}#proc-commands-managing-kafka_getting-started-rhoas-kafka[Use `rhoas` to manage your Kafka instances, service accounts, and Kafka topics]
+* {base-url}{rhoas-cli-getting-started-url-kafka}#proc-creating-kafka-instance-cli_getting-started-rhoas-kafka[Create a Kafka instance]
+* {base-url}{rhoas-cli-getting-started-url-kafka}#proc-creating-service-account-cli_getting-started-rhoas-kafka[Create a service account]
+* {base-url}{rhoas-cli-getting-started-url-kafka}#proc-creating-kafka-topic-cli_getting-started-rhoas-kafka[Create a Kafka topic]
+* {base-url}{rhoas-cli-getting-started-url-kafka}#proc-commands-managing-kafka_getting-started-rhoas-kafka[Use `rhoas` to manage your Kafka instances, service accounts, and Kafka topics]
 
 //Additional line break to resolve mod docs generation error
 

--- a/docs/kafka/service-binding-kafka/README.adoc
+++ b/docs/kafka/service-binding-kafka/README.adoc
@@ -175,10 +175,10 @@ Also, you can observe that the RHOAS Operator is installed in the `openshift-ope
 After you install the RHOAS Operator, you can verify that the Operator is working by using the RHOAS CLI to connect to your OpenShift cluster and retrieve the cluster status. The following example shows how to verify connection to your OpenShift cluster.
 
 .Prerequisites
-* The RHOAS Operator is installed on your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-installing-rhoas-operator_{context}[Installing the RHOAS Operator on OpenShift].
+* The RHOAS Operator is installed on your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-installing-rhoas-operator_{context}[Installing the RHOAS Operator on OpenShift].
 * You can access your OpenShift cluster with privileges to create a new project.
 * You've installed the OpenShift CLI. For more information, see link:https://docs.openshift.com/container-platform/4.8/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli[Installing the OpenShift CLI^].
-* You've installed the latest version of the RHOAS CLI. For more information, see link:{base-url}{rhoas-cli-installation-url}[Installing the RHOAS CLI^].
+* You've installed the latest version of the RHOAS CLI. For more information, see {base-url}{rhoas-cli-installation-url}[Installing the RHOAS CLI^].
 
 .Procedure
 . On your computer, open a command-line window.
@@ -230,14 +230,14 @@ As shown in the output, the RHOAS CLI indicates that the RHOAS Operator was succ
 When you've verified connection to your OpenShift cluster, you can connect a Kafka instance in {product-kafka} to the current project in the cluster. You must establish this connection before you can bind applications running in the project to the Kafka instance. The following example shows how to use the RHOAS CLI to connect a specified Kafka instance to a project in your cluster.
 
 .Prerequisites
-* You've installed the RHOAS Operator and verified connection to your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
-* You’ve created a Kafka instance in {product-kafka} and the instance is in the *Ready* state. To learn how to create a Kafka instance, see link:{base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}^].
+* You've installed the RHOAS Operator and verified connection to your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
+* You’ve created a Kafka instance in {product-kafka} and the instance is in the *Ready* state. To learn how to create a Kafka instance, see {base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}^].
 * You have an API token to connect to your Kafka instance. To get a token, see the link:https://console.redhat.com/openshift/token[OpenShift Cluster Manager API Token^] page.
 * You understand how Access Control Lists (ACLs) enable you to manage how user accounts and service accounts can access the Kafka resources that you create. For more information, see {base-url}{access-mgmt-url-kafka}[Managing account access in {product-long-kafka}^].
 
 .Procedure
 
-. If you're not already logged in to the OpenShift CLI, log in using a token, as described in link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
+. If you're not already logged in to the OpenShift CLI, log in using a token, as described in {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
 
 . Log in to the RHOAS CLI.
 +
@@ -365,9 +365,9 @@ When you perform service binding, the Service Binding Operator automatically inj
 In general, this automatic injection and detection of connection parameters eliminates the need to manually configure an application to connect to a Kafka instance in {product-kafka}. This is a particular advantage if you have many applications in your project that you want to connect to a Kafka instance.
 
 === Prerequisites
-* The Service Binding Operator is installed on your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-installing-service-binding-operator_{context}[Installing the Service Binding Operator on OpenShift].
-* The RHOAS Operator is installed on your OpenShift cluster and you've verified connection to the cluster. See link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
-* You've connected a Kafka instance to a project in your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-connecting-kafka-instance-to-openshift-cluster_{context}[Connecting a Kafka instance to your OpenShift cluster].
+* The Service Binding Operator is installed on your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-installing-service-binding-operator_{context}[Installing the Service Binding Operator on OpenShift].
+* The RHOAS Operator is installed on your OpenShift cluster and you've verified connection to the cluster. See {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
+* You've connected a Kafka instance to a project in your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-connecting-kafka-instance-to-openshift-cluster_{context}[Connecting a Kafka instance to your OpenShift cluster].
 
 [id="proc-deploying-example-quarkus-application-on-openshift_{context}"]
 === Deploying an example Quarkus application on OpenShift
@@ -384,7 +384,7 @@ The example Quarkus application uses the `quarkus-kubernetes-service-binding` li
 
 .Procedure
 
-. If you're not already logged in to the OpenShift CLI, log in using a token, as described in link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster]. Log in as the same user who verified connection to the cluster.
+. If you're not already logged in to the OpenShift CLI, log in using a token, as described in {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster]. Log in as the same user who verified connection to the cluster.
 
 . Use the OpenShift CLI to ensure that the current OpenShift project is the one that you previously connected your Kafka instance to, as shown in the following example.
 +
@@ -436,11 +436,11 @@ A new web page entitled *Last price* opens.  Because you haven't yet connected t
 In the previous step of this tutorial, you deployed an example application on OpenShift. The application is a Quarkus application that uses a Kafka topic called `prices` to produce and consume messages. In this step, you create the `prices` topic in your Kafka instance.
 
 .Prerequisites
-* You've deployed the example Quarkus application. See link:{base-url}{service-binding-url-kafka}#proc-deploying-example-quarkus-application-on-openshift_{context}[Deploying an example Quarkus application on OpenShift].
-* You’ve created a Kafka instance in {product-kafka} and the instance is in the *Ready* state. To learn how to create a Kafka instance, see link:{base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}^].
+* You've deployed the example Quarkus application. See {base-url}{service-binding-url-kafka}#proc-deploying-example-quarkus-application-on-openshift_{context}[Deploying an example Quarkus application on OpenShift].
+* You’ve created a Kafka instance in {product-kafka} and the instance is in the *Ready* state. To learn how to create a Kafka instance, see {base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}^].
 
 .Procedure
-. On the link:{service-url-kafka}[Kafka Instances^] page of the {product-kafka} web console, click the name of the Kafka instance that you want to add a topic to.
+. On the {service-url-kafka}[Kafka Instances^] page of the {product-kafka} web console, click the name of the Kafka instance that you want to add a topic to.
 
 . Select the *Topics* tab, click *Create topic*, and follow the guided steps to define the details of the `prices` topic. Click *Next* to complete each step and click *Finish* to complete the setup.
 +
@@ -464,15 +464,15 @@ After you complete the topic setup, the new Kafka topic is listed in the topics 
 In this step of the tutorial, you use the RHOAS CLI to bind the example Quarkus application that you deployed on OpenShift to your Kafka instance. When you perform this binding, the Service Binding Operator injects connection parameters as files into the pod for the application. The Quarkus application automatically detects and uses the connection parameters to bind to the Kafka instance.
 
 .Prerequisites
-* You understand how the Service Binding Operator injects connection parameters as files into the pod for a client application. See link:{base-url}{service-binding-url-kafka}#con-about-service-binding_{context}[About service binding].
-* The Service Binding Operator is installed on your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-installing-service-binding-operator_{context}[Installing the Service Binding Operator on OpenShift].
-* The RHOAS Operator is installed on your OpenShift cluster and you've verified connection to the cluster. See link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
-* You've connected a Kafka instance to a project in your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-connecting-kafka-instance-to-openshift-cluster_{context}[Connecting a Kafka instance to your OpenShift cluster].
-* You've deployed the example Quarkus application. See link:{base-url}{service-binding-url-kafka}#proc-deploying-example-quarkus-application-on-openshift_{context}[Deploying an example Quarkus application on OpenShift].
-* You've created the topic required by the Quarkus application. See link:{base-url}{service-binding-url-kafka}#proc-creating-prices-topic-in-kafka-instance_{context}[Creating the prices topic in your Kafka instance].
+* You understand how the Service Binding Operator injects connection parameters as files into the pod for a client application. See {base-url}{service-binding-url-kafka}#con-about-service-binding_{context}[About service binding].
+* The Service Binding Operator is installed on your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-installing-service-binding-operator_{context}[Installing the Service Binding Operator on OpenShift].
+* The RHOAS Operator is installed on your OpenShift cluster and you've verified connection to the cluster. See {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
+* You've connected a Kafka instance to a project in your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-connecting-kafka-instance-to-openshift-cluster_{context}[Connecting a Kafka instance to your OpenShift cluster].
+* You've deployed the example Quarkus application. See {base-url}{service-binding-url-kafka}#proc-deploying-example-quarkus-application-on-openshift_{context}[Deploying an example Quarkus application on OpenShift].
+* You've created the topic required by the Quarkus application. See {base-url}{service-binding-url-kafka}#proc-creating-prices-topic-in-kafka-instance_{context}[Creating the prices topic in your Kafka instance].
 
 .Procedure
-. If you're not already logged in to the OpenShift CLI, log in using a token, as described in link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster]. Log in as the same user who verified connection to the cluster.
+. If you're not already logged in to the OpenShift CLI, log in using a token, as described in {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster]. Log in as the same user who verified connection to the cluster.
 
 . Log in to the RHOAS CLI.
 +
@@ -539,9 +539,9 @@ In general, this automatic injection and detection of connection parameters elim
 
 === Prerequisites
 * Your OpenShift cluster is running on OpenShift 4.8 or later.
-* The Service Binding Operator is installed on your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-installing-service-binding-operator_{context}[Installing the Service Binding Operator on OpenShift].
-* The RHOAS Operator is installed on your OpenShift cluster and you've verified connection to the cluster. See link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
-* You've connected a Kafka instance to a project in your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-connecting-kafka-instance-to-openshift-cluster_{context}[Connecting a Kafka instance to your OpenShift cluster].
+* The Service Binding Operator is installed on your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-installing-service-binding-operator_{context}[Installing the Service Binding Operator on OpenShift].
+* The RHOAS Operator is installed on your OpenShift cluster and you've verified connection to the cluster. See {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
+* You've connected a Kafka instance to a project in your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-connecting-kafka-instance-to-openshift-cluster_{context}[Connecting a Kafka instance to your OpenShift cluster].
 
 [id="proc-deploying-example-nodejs-application-on-openshift_{context}"]
 === Deploying an example Node.js application on OpenShift
@@ -569,7 +569,7 @@ The *Topology* page opens.
 .. At the top of the *Topology* page, click the *Project* drop-down menu.
 .. Select the project that you previously connected your Kafka instance to.
 
-. If you're not already logged in to the OpenShift CLI, log in using a token, as described in link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster]. Log in as the same user who verified connection to the cluster.
+. If you're not already logged in to the OpenShift CLI, log in using a token, as described in {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster]. Log in as the same user who verified connection to the cluster.
 
 . On the command line, clone the Nodeshift Application Starters link:https://github.com/nodeshift-starters/reactive-example[reactive-example^] repository from GitHub.
 +
@@ -647,11 +647,11 @@ In the logs, you should see errors indicating that the producer component can't 
 In the previous step of this tutorial, you deployed an example application on OpenShift. The application is a Node.js application that uses a Kafka topic called `countries` to produce and consume messages. In this step, you'll create the `countries` topic in your Kafka instance.
 
 .Prerequisites
-* You've deployed the example Node.js application. See link:{base-url}{service-binding-url-kafka}#proc-deploying-example-nodejs-application-on-openshift_{context}[Deploying an example Node.js application on OpenShift].
-* You’ve created a Kafka instance in {product-kafka} and the instance is in the *Ready* state. To learn how to create a Kafka instance, see link:{base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}^].
+* You've deployed the example Node.js application. See {base-url}{service-binding-url-kafka}#proc-deploying-example-nodejs-application-on-openshift_{context}[Deploying an example Node.js application on OpenShift].
+* You’ve created a Kafka instance in {product-kafka} and the instance is in the *Ready* state. To learn how to create a Kafka instance, see {base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}^].
 
 .Procedure
-. On the link:{service-url-kafka}[Kafka Instances^] page of the {product-kafka} web console, click the name of the Kafka instance that you want to add a topic to.
+. On the {service-url-kafka}[Kafka Instances^] page of the {product-kafka} web console, click the name of the Kafka instance that you want to add a topic to.
 
 . Select the *Topics* tab, click *Create topic*, and follow the guided steps to define the details of the `countries` topic. Click *Next* to complete each step and click *Finish* to complete the setup.
 +
@@ -677,12 +677,12 @@ In this step of the tutorial, you use the OpenShift web console to bind the comp
 The example Node.js application uses the `kube-service-bindings` link:https://www.npmjs.com/package/kube-service-bindings[package^]. This means that the application automatically detects and uses the injected connection parameters.
 
 .Prerequisites
-* You understand how the Service Binding Operator injects connection parameters as files into the pod for a client application. See link:{base-url}{service-binding-url-kafka}#con-about-service-binding_{context}[About service binding].
-* The Service Binding Operator is installed on your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-installing-service-binding-operator_{context}[Installing the Service Binding Operator on OpenShift].
-* The RHOAS Operator is installed on your OpenShift cluster and you've verified connection to the cluster. See link:{base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
-* You've connected a Kafka instance to a project in your OpenShift cluster. See link:{base-url}{service-binding-url-kafka}#proc-connecting-kafka-instance-to-openshift-cluster_{context}[Connecting a Kafka instance to your OpenShift cluster].
-* You've deployed the example Node.js application. See link:{base-url}{service-binding-url-kafka}#proc-deploying-example-nodejs-application-on-openshift_{context}[Deploying an example Node.js application on OpenShift].
-* You've created the topic required by the Node.js application. See link:{base-url}{service-binding-url-kafka}#proc-creating-countries-topic-in-kafka-instance_{context}[Creating the countries topic in your Kafka instance].
+* You understand how the Service Binding Operator injects connection parameters as files into the pod for a client application. See {base-url}{service-binding-url-kafka}#con-about-service-binding_{context}[About service binding].
+* The Service Binding Operator is installed on your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-installing-service-binding-operator_{context}[Installing the Service Binding Operator on OpenShift].
+* The RHOAS Operator is installed on your OpenShift cluster and you've verified connection to the cluster. See {base-url}{service-binding-url-kafka}#proc-verifying-connection-to-openshift-cluster_{context}[Verifying connection to your OpenShift cluster].
+* You've connected a Kafka instance to a project in your OpenShift cluster. See {base-url}{service-binding-url-kafka}#proc-connecting-kafka-instance-to-openshift-cluster_{context}[Connecting a Kafka instance to your OpenShift cluster].
+* You've deployed the example Node.js application. See {base-url}{service-binding-url-kafka}#proc-deploying-example-nodejs-application-on-openshift_{context}[Deploying an example Node.js application on OpenShift].
+* You've created the topic required by the Node.js application. See {base-url}{service-binding-url-kafka}#proc-creating-countries-topic-in-kafka-instance_{context}[Creating the countries topic in your Kafka instance].
 
 .Procedure
 

--- a/docs/registry/getting-started-registry/README.adoc
+++ b/docs/registry/getting-started-registry/README.adoc
@@ -89,7 +89,7 @@ ifndef::qs[]
 endif::[]
 
 .Procedure
-. In the link:{service-url-registry}[{registry} web console], click *Create {registry} instance*.
+. In the {service-url-registry}[{registry} web console], click *Create {registry} instance*.
 . Enter a unique *Instance name*, such as `my-service-registry-instance`.
 
 . Click *Create* to start the creation process for your {registry} instance. The new {registry} instance is listed in the instances table.
@@ -261,7 +261,7 @@ endif::[]
 
 [role="_additional-resources"]
 == Additional resources
-* link:{base-url}{access-mgmt-url-registry}[Managing account access in Red Hat OpenShift Service Registry^]
+* {base-url}{access-mgmt-url-registry}[Managing account access in Red Hat OpenShift Service Registry^]
 * https://access.redhat.com/documentation/en-us/red_hat_openshift_service_registry/1[{product-long-registry} user documentation^]
 * https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1[OpenShift Streams for Apache Kafka user documentation^]
 

--- a/docs/registry/quarkus-registry/README.adoc
+++ b/docs/registry/quarkus-registry/README.adoc
@@ -66,8 +66,8 @@ Quarkus is designed to work with popular Java standards, frameworks, and librari
 ifndef::community[]
 * You have a Red Hat account.
 endif::[]
-* You have a running Kafka instance in {product-kafka} (see link:{base-url}{getting-started-url-kafka}[Getting started with Kafka^]).
-* You have a running {registry} instance in {product-long-registry} (see link:{base-url}{getting-started-url-registry}[Getting started with {registry}^]).
+* You have a running Kafka instance in {product-kafka} (see {base-url}{getting-started-url-kafka}[Getting started with Kafka^]).
+* You have a running {registry} instance in {product-long-registry} (see {base-url}{getting-started-url-registry}[Getting started with {registry}^]).
 * https://github.com/git-guides/[Git^] is installed.
 * You have an IDE such as https://www.jetbrains.com/idea/download/[IntelliJ IDEA^], https://www.eclipse.org/downloads/[Eclipse^], or https://code.visualstudio.com/Download[VSCode^].
 * https://adoptopenjdk.net/[OpenJDK^] 11 or later is installed on Linux or MacOS.
@@ -88,10 +88,10 @@ endif::[]
 == Importing the Quarkus sample code
 
 [role="_abstract"]
-For this quick start, you'll use the Quarkus {registry} sample code from the App Services link:{samples-git-repo}[Guides and Samples^] repository in GitHub. After you understand the concepts and tasks in this quick start, you can use your own Quarkus applications with {product-kafka} and {registry} in the same way.
+For this quick start, you'll use the Quarkus {registry} sample code from the App Services {samples-git-repo}[Guides and Samples^] repository in GitHub. After you understand the concepts and tasks in this quick start, you can use your own Quarkus applications with {product-kafka} and {registry} in the same way.
 
 .Procedure
-. On the command line, clone the App Services link:{samples-git-repo}[Guides and Samples^] repository from GitHub.
+. On the command line, clone the App Services {samples-git-repo}[Guides and Samples^] repository from GitHub.
 +
 .Cloning the guides and samples repository
 [source,subs="+attributes"]
@@ -119,7 +119,7 @@ This Quarkus example application includes producer and consumer processes that s
 
 .Prerequisites
 ifndef::qs[]
-* You have a service account with write access to Kafka and {registry} instances and have stored your credentials securely (see link:{base-url}{getting-started-url-kafka}[Getting started with Kafka^] and link:{base-url}{getting-started-url-registry}[Getting started with {registry}^]).
+* You have a service account with write access to Kafka and {registry} instances and have stored your credentials securely (see {base-url}{getting-started-url-kafka}[Getting started with Kafka^] and {base-url}{getting-started-url-registry}[Getting started with {registry}^]).
 * You have the Kafka bootstrap server endpoint for the Kafka instance. You copied this information previously for the Kafka instance in {product-kafka} by selecting the options menu (three vertical dots) and clicking *Connection*.
 * You have the Core Registry API endpoint for the {registry} instance. You copied this information for the {registry} instance by selecting the options menu (three vertical dots) and clicking *Connection*. From the list of endpoints, you copied the *Core Registry API* endpoint supported by the Apicurio serializer/deserializer (SerDes) used in this example.
 * You copied the *Token endpoint URL* value from the same list of endpoints to be used for the OAuth-based athentication method used in this example.

--- a/docs/registry/rhoas-cli-getting-started-registry/README.adoc
+++ b/docs/registry/rhoas-cli-getting-started-registry/README.adoc
@@ -63,12 +63,12 @@ Artifacts are items stored in {registry}, like schemas and API specifications.
 
 This guide describes how to get started quickly by doing the following tasks:
 
-* link:{base-url}{rhoas-cli-getting-started-url-registry}#proc-creating-service-registry-instance-cli_getting-started-rhoas-service-registry[Create a {registry} instance]
-* link:{base-url}{rhoas-cli-getting-started-url-registry}#proc-creating-service-registry-account_getting-started-rhoas-service-registry[Create a service account]
-* link:{base-url}{rhoas-cli-getting-started-url-registry}#proc-uploading-service-registry-artifacts_getting-started-rhoas-service-registry[Upload {registry} artifacts]
-* link:{base-url}{rhoas-cli-getting-started-url-registry}#proc-downloading-service-registry-artifacts_getting-started-rhoas-service-registry[Download {registry} artifacts]
-* link:{base-url}{rhoas-cli-getting-started-url-registry}#proc-updating-service-registry-artifacts_getting-started-rhoas-service-registry[Update {registry} artifacts]
-* link:{base-url}{rhoas-cli-getting-started-url-registry}#proc-commands-managing-registry_getting-started-rhoas-service-registry[Use `rhoas` to manage your {registry} instance, service accounts, and artifacts]
+* {base-url}{rhoas-cli-getting-started-url-registry}#proc-creating-service-registry-instance-cli_getting-started-rhoas-service-registry[Create a {registry} instance]
+* {base-url}{rhoas-cli-getting-started-url-registry}#proc-creating-service-registry-account_getting-started-rhoas-service-registry[Create a service account]
+* {base-url}{rhoas-cli-getting-started-url-registry}#proc-uploading-service-registry-artifacts_getting-started-rhoas-service-registry[Upload {registry} artifacts]
+* {base-url}{rhoas-cli-getting-started-url-registry}#proc-downloading-service-registry-artifacts_getting-started-rhoas-service-registry[Download {registry} artifacts]
+* {base-url}{rhoas-cli-getting-started-url-registry}#proc-updating-service-registry-artifacts_getting-started-rhoas-service-registry[Update {registry} artifacts]
+* {base-url}{rhoas-cli-getting-started-url-registry}#proc-commands-managing-registry_getting-started-rhoas-service-registry[Use `rhoas` to manage your {registry} instance, service accounts, and artifacts]
 
 //Additional line break to resolve mod docs generation error
 

--- a/docs/rhoas/rhoas-cli-installation/README.adoc
+++ b/docs/rhoas/rhoas-cli-installation/README.adoc
@@ -59,10 +59,10 @@ With the {product-long-rhoas} `rhoas` command-line interface (CLI), you can mana
 This guide describes how to set up `rhoas` by doing the following:
 
 --
-* link:{base-url}{rhoas-cli-installation-url}#proc-installing-rhoas_installing-rhoas-cli[Install `rhoas` on your operating system]
-* link:{base-url}{rhoas-cli-installation-url}#proc-configuring-rhoas_installing-rhoas-cli[Configure `rhoas` to enable command completion]
-* link:{base-url}{rhoas-cli-installation-url}#proc-logging-in-to-rhoas_installing-rhoas-cli[Log in to `rhoas`]
-* link:{base-url}{rhoas-cli-installation-url}#proc-logging-out-rhoas_installing-rhoas-cli[Log out of `rhoas`]
+* {base-url}{rhoas-cli-installation-url}#proc-installing-rhoas_installing-rhoas-cli[Install `rhoas` on your operating system]
+* {base-url}{rhoas-cli-installation-url}#proc-configuring-rhoas_installing-rhoas-cli[Configure `rhoas` to enable command completion]
+* {base-url}{rhoas-cli-installation-url}#proc-logging-in-to-rhoas_installing-rhoas-cli[Log in to `rhoas`]
+* {base-url}{rhoas-cli-installation-url}#proc-logging-out-rhoas_installing-rhoas-cli[Log out of `rhoas`]
 --
 
 //Additional line break to resolve mod docs generation error
@@ -222,9 +222,9 @@ To determine which shell you are using, run the `echo $0` command.
 
 You can enable command completion for each of the following shells:
 
-* link:{base-url}{rhoas-cli-installation-url}#enabling-command-completion-bash_installing-rhoas-cli[Bash]
-* link:{base-url}{rhoas-cli-installation-url}#enabling-command-completion-zsh_installing-rhoas-cli[Zsh]
-* link:{base-url}{rhoas-cli-installation-url}#enabling-command-completion-fish_installing-rhoas-cli[Fish]
+* {base-url}{rhoas-cli-installation-url}#enabling-command-completion-bash_installing-rhoas-cli[Bash]
+* {base-url}{rhoas-cli-installation-url}#enabling-command-completion-zsh_installing-rhoas-cli[Zsh]
+* {base-url}{rhoas-cli-installation-url}#enabling-command-completion-fish_installing-rhoas-cli[Fish]
 
 .Prerequisites
 


### PR DESCRIPTION
@smccarthy-ie Discovered in sanity checks this publish that some of the URLs that were displayed from certain cross-refs in the docs were showing the attributes. I believe this is do to the format `see link:{variable}` instead of just `see {variable}`, which this PR fixes throughout the docs project.