### PR TITLE
fix: swap JDK to recommend OpenJDK instead

### DIFF
--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -66,7 +66,7 @@ ifndef::community[]
 //* You have a subscription to {product-long-kafka}. For more information about signing up, see *<@SME: Where to link?>*.
 endif::[]
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
-* For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
+* We recomend using latest LTS version of OpenJDK 17.
 
 // Condition out QS-only content so that it doesn't appear in docs.
 // All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.

--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -66,7 +66,7 @@ ifndef::community[]
 //* You have a subscription to {product-long-kafka}. For more information about signing up, see *<@SME: Where to link?>*.
 endif::[]
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
-* We recomend using latest LTS version of OpenJDK 17.
+* Latest LTS version of OpenJDK is recommended 
 
 // Condition out QS-only content so that it doesn't appear in docs.
 // All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.

--- a/docs/kafka/kafka-bin-scripts-kafka/README.adoc
+++ b/docs/kafka/kafka-bin-scripts-kafka/README.adoc
@@ -75,7 +75,7 @@ ifndef::community[]
 endif::[]
 * You have a running Kafka instance in {product-kafka}.
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
-* For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
+* We recomend using latest LTS version of OpenJDK 17.
 * You've downloaded the latest supported binary version of the https://kafka.apache.org/downloads[Apache Kafka distribution^]. You can check your version using the following command.
 +
 .Verifying Kafka scripts

--- a/docs/kafka/kafka-bin-scripts-kafka/README.adoc
+++ b/docs/kafka/kafka-bin-scripts-kafka/README.adoc
@@ -75,7 +75,7 @@ ifndef::community[]
 endif::[]
 * You have a running Kafka instance in {product-kafka}.
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
-* We recomend using latest LTS version of OpenJDK 17.
+* Latest LTS version of OpenJDK is recommended 
 * You've downloaded the latest supported binary version of the https://kafka.apache.org/downloads[Apache Kafka distribution^]. You can check your version using the following command.
 +
 .Verifying Kafka scripts

--- a/docs/kafka/kcat-kafka/README.adoc
+++ b/docs/kafka/kcat-kafka/README.adoc
@@ -74,7 +74,6 @@ endif::[]
 //* You have a subscription to {product-long-kafka}. For more information about signing up, see *<@SME: Where to link?>*.
 * You have a running Kafka instance in {product-kafka}.
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
-* We recomend using latest LTS version of OpenJDK 17.
 * You have installed the latest supported version of https://github.com/edenhill/kafkacat[Kafkacat^] for your operating system.
 +
 .Verifying Kafkacat installation

--- a/docs/kafka/kcat-kafka/README.adoc
+++ b/docs/kafka/kcat-kafka/README.adoc
@@ -74,7 +74,7 @@ endif::[]
 //* You have a subscription to {product-long-kafka}. For more information about signing up, see *<@SME: Where to link?>*.
 * You have a running Kafka instance in {product-kafka}.
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
-* For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
+* We recomend using latest LTS version of OpenJDK 17.
 * You have installed the latest supported version of https://github.com/edenhill/kafkacat[Kafkacat^] for your operating system.
 +
 .Verifying Kafkacat installation

--- a/docs/kafka/quarkus-kafka/README.adoc
+++ b/docs/kafka/quarkus-kafka/README.adoc
@@ -67,7 +67,7 @@ endif::[]
 * You have an IDE such as https://www.jetbrains.com/idea/download/[IntelliJ IDEA^], https://www.eclipse.org/downloads/[Eclipse^], or https://code.visualstudio.com/Download[VSCode^].
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
 * https://maven.apache.org/[Apache Maven^] 3.6.2 or later is installed.
-* We recomend using latest LTS version of OpenJDK 17.
+* Latest LTS version of OpenJDK is recommended 
 
 // Condition out QS-only content so that it doesn't appear in docs.
 // All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.

--- a/docs/kafka/quarkus-kafka/README.adoc
+++ b/docs/kafka/quarkus-kafka/README.adoc
@@ -67,7 +67,7 @@ endif::[]
 * You have an IDE such as https://www.jetbrains.com/idea/download/[IntelliJ IDEA^], https://www.eclipse.org/downloads/[Eclipse^], or https://code.visualstudio.com/Download[VSCode^].
 * https://adoptopenjdk.net/[JDK^] 11 or later is installed.
 * https://maven.apache.org/[Apache Maven^] 3.6.2 or later is installed.
-* For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
+* We recomend using latest LTS version of OpenJDK 17.
 
 // Condition out QS-only content so that it doesn't appear in docs.
 // All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.

--- a/docs/registry/quarkus-registry/README.adoc
+++ b/docs/registry/quarkus-registry/README.adoc
@@ -72,7 +72,7 @@ endif::[]
 * You have an IDE such as https://www.jetbrains.com/idea/download/[IntelliJ IDEA^], https://www.eclipse.org/downloads/[Eclipse^], or https://code.visualstudio.com/Download[VSCode^].
 * https://adoptopenjdk.net/[OpenJDK^] 11 or later is installed on Linux or MacOS.
 * https://maven.apache.org/[Apache Maven^] 3.8.x or later is installed (for Quarkus 2.2.x).
-* For Windows, the latest version of https://www.oracle.com/java/technologies/javase-downloads.html[Oracle JDK^] is installed.
+* We recomend using latest LTS version of OpenJDK 17.
 
 // Condition out QS-only content so that it doesn't appear in docs.
 // All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.

--- a/docs/registry/quarkus-registry/README.adoc
+++ b/docs/registry/quarkus-registry/README.adoc
@@ -72,7 +72,7 @@ endif::[]
 * You have an IDE such as https://www.jetbrains.com/idea/download/[IntelliJ IDEA^], https://www.eclipse.org/downloads/[Eclipse^], or https://code.visualstudio.com/Download[VSCode^].
 * https://adoptopenjdk.net/[OpenJDK^] 11 or later is installed on Linux or MacOS.
 * https://maven.apache.org/[Apache Maven^] 3.8.x or later is installed (for Quarkus 2.2.x).
-* We recomend using latest LTS version of OpenJDK 17.
+* Latest LTS version of OpenJDK is recommended 
 
 // Condition out QS-only content so that it doesn't appear in docs.
 // All QS anchor IDs must be in this alternate anchor ID format `[#anchor-id]` because the ascii splitter relies on the other format `[id="anchor-id"]` to generate module files.


### PR DESCRIPTION
Replace OracleJDK recommendation with OpenJDK (17). 
Actual description can be reviewed and improved depending on how we want to put recommendation in place. 



