### PR TITLE
Update the product mapping for RHOAS CLI doc

### DIFF
--- a/docs/.product-mapping.yml
+++ b/docs/.product-mapping.yml
@@ -8,16 +8,15 @@ products:
     ## For example kafka/access-mgmt etc.
     directories:
       - kafka
-      - rhoas
   RHOSR:
     directories:
       - registry
-      - rhoas
   RHOC:
     directories:
       - connectors
-      - rhoas
   RHODA:
     directories:
       - database-access
+  RHOAS:
+    directories:
       - rhoas


### PR DESCRIPTION
The RHOAS CLI doc will now be published downstream as a separate product, so I added a new entry for it.