### PR TITLE
Update modular-docs-publish.yml

### DIFF
--- a/.github/workflows/modular-docs-publish.yml
+++ b/.github/workflows/modular-docs-publish.yml
@@ -19,6 +19,8 @@ jobs:
               branch: modular-docs-rhosak
             - product: RHOSR
               branch: modular-docs-rhosr
+            - product: RHOAS
+              branch: modular-docs-rhoas
             # - product: RHODA
             #  branch: modular-docs-rhoda 
             # - product: RHOC


### PR DESCRIPTION
Add the RHOAS product to the matrix.

Tagged a new release and didn't see the new RHOAS guides being built. Then I realized I neglected to add the RHOAS product to the workflow. 🤦