### PR TITLE
fix links and attributes on project readme pages

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,6 +1,9 @@
 :product: App Services
+:product-kafka: Streams for Apache Kafka
+:product-registry: Service Registry
 
-= Contributing to {product-kafka} guides
+= Contributing to {product} guides
+
 
 == Prerequisites
 
@@ -41,7 +44,7 @@ npm --prefix .build run generate:attributes
 
 == Repository structure
 
-This repository is designed to be usable for people browsing it on GitHub, as well as reusable (e.g. in quick starts) in implementations of {product-kafka}.
+This repository is designed to be usable for people browsing it on GitHub, as well as reusable (e.g., in quick starts) in implementations of services such as {product-kafka} or {product-registry}.
 
 Each guide is contained in a separate directory. The directory must contain:
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -44,7 +44,7 @@ npm --prefix .build run generate:attributes
 
 == Repository structure
 
-This repository is designed to be usable for people browsing it on GitHub, as well as reusable (e.g., in quick starts) in implementations of services such as {product-kafka} or {product-registry}.
+This repository is designed to be usable for people browsing it on GitHub, as well as reusable (for example, in quick starts) in implementations of services such as {product-kafka} or {product-registry}.
 
 Each guide is contained in a separate directory. The directory must contain:
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,31 +1,39 @@
 :product: App Services
+:product-long-kafka: OpenShift Streams for Apache Kafka
+:product-long-registry: OpenShift Service Registry
 
+= {product} guides and samples
 
+== {product-long-kafka} guides
 
-= {product} Guides and Samples
+* link:./docs/kafka/getting-started-kafka[Getting started with {product-long-kafka}]
+* link:./docs/kafka/rhoas-cli-getting-started-kafka[Getting started with the `rhoas` CLI for {product-long-kafka}]
+* link:./docs/kafka/quarkus-kafka[Using Quarkus applications with Kafka instances in {product-long-kafka}]
+* link:./docs/kafka/kcat-kafka[Using Kafkacat with Kafka instances in {product-long-kafka}]
+* link:./docs/kafka/kafka-bin-scripts-kafka[Using Kafka bin scripts with {product-long-kafka}]
+* link:./docs/kafka/access-mgmt-kafka[Managing account access in {product-long-kafka}]
+* link:./docs/kafka/service-binding-kafka[Binding OpenShift applications to {product-long-kafka}]
+* link:./docs/kafka/topic-configuration-kafka[Configuring topics in {product-long-kafka}]
+* link:./docs/kafka/nodejs-kafka[Using Node.js applications with Kafka instances in {product-long-kafka}]
+* link:./docs/kafka/metrics-monitoring-kafka[Monitoring metrics in {product-long-kafka}]
+* link:./docs/docs/kafka/consumer-configuration-kafka[Configuring consumer groups in {product-long-kafka}]
 
-== Guides
+== {product-long-registry} guides
 
-* link:./docs/kafka/getting-started[Getting started with {product-kafka}]
-* link:./rhoas-cli[Installing and configuring the `rhoas` CLI]
-* link:./docs/service-discovery[Binding OpenShift applications to {product-kafka}]
+* link:./docs/registry/getting-started-registry/[Getting started with {product-long-registry}]
+* link:./docs/registry/access-mgmt-registry[Managing account access in {product-long-registry}]
+* link:./docs/registry/rhoas-cli-registry[Getting started with the `rhoas` CLI for {product-long-registry}]
+* link:./docs/registry/quarkus-registry[Using Quarkus applications with Kafka and {product-long-registry} instances]
 
-== OpenShift Streams For Apache Kafka Guides
+== Common guides
 
-* link:./docs/kafka/rhoas-cli-kafka[Getting started with the `rhoas` CLI for OpenShift Streams for Apache Kafka]
-* link:./docs/kafka/quarkus[Using Quarkus applications with Kafka instances in {product-kafka}]
-* link:./docs/kafka/kafkacat[Using Kafkacat with Kafka instances in {product-kafka}]
-* link:./docs/kafka/kafka-bin-scripts[Using Kafka bin scripts with {product-kafka}]
-
-== OpenShift Service Registry Guides
-
-* link:./docs/registry/rhoas-cli-service-registry[Getting started with the `rhoas` CLI for OpenShift Service Registry]
-* link:./docs/registry/getting-started-service-registry/[Getting started with Service Registry]
+* link:./docs/rhoas/rhoas-cli-installation[Installing and configuring the `rhoas` CLI]
 
 == Application examples used in guides
 
 * link:./code-examples/quarkus-kafka-quickstart[Quarkus Kafka quick start]
+* link:./code-examples/quarkus-service-registry-quickstart[Quarkus Kafka Service Registry quick start]
 
 == Contributing
 
-* link:./CONTRIBUTING.adoc[Contributing to {product-kafka} guides]
+* link:./CONTRIBUTING.adoc[Contributing to {product} guides]

--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@
 * link:./docs/registry/getting-started-registry/[Getting started with {product-long-registry}]
 * link:./docs/registry/access-mgmt-registry[Managing account access in {product-long-registry}]
 * link:./docs/registry/rhoas-cli-registry[Getting started with the `rhoas` CLI for {product-long-registry}]
-* link:./docs/registry/quarkus-registry[Using Quarkus applications with Kafka and {product-long-registry} instances]
+* link:./docs/registry/quarkus-registry[Using Quarkus applications with Kafka instances and {product-long-registry} instances]
 
 == Common guides
 

--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@
 * link:./docs/kafka/topic-configuration-kafka[Configuring topics in {product-long-kafka}]
 * link:./docs/kafka/nodejs-kafka[Using Node.js applications with Kafka instances in {product-long-kafka}]
 * link:./docs/kafka/metrics-monitoring-kafka[Monitoring metrics in {product-long-kafka}]
-* link:./docs/docs/kafka/consumer-configuration-kafka[Configuring consumer groups in {product-long-kafka}]
+* link:./docs/kafka/consumer-configuration-kafka[Configuring consumer groups in {product-long-kafka}]
 
 == {product-long-registry} guides
 

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@
 == {product-long-kafka} guides
 
 * link:./docs/kafka/getting-started-kafka[Getting started with {product-long-kafka}]
-* link:./docs/kafka/rhoas-cli-getting-started-kafka[Getting started with the `rhoas` CLI for {product-long-kafka}]
+* link:./docs/kafka/rhoas-cli-getting-started-kafka[Getting started with the rhoas CLI for {product-long-kafka}]
 * link:./docs/kafka/quarkus-kafka[Using Quarkus applications with Kafka instances in {product-long-kafka}]
 * link:./docs/kafka/kcat-kafka[Configuring and connecting Kafkacat with {product-long-kafka}]
 * link:./docs/kafka/kafka-bin-scripts-kafka[Configuring and connecting Kafka scripts with {product-long-kafka}]

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@
 * link:./docs/registry/rhoas-cli-registry[Getting started with the rhoas CLI for {product-long-registry}]
 * link:./docs/registry/quarkus-registry[Using Quarkus applications with Kafka instances and {product-long-registry} instances]
 
-== Common guides
+== Core guides
 
 * link:./docs/rhoas/rhoas-cli-installation[Installing and configuring the rhoas CLI]
 

--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@
 * link:./docs/kafka/getting-started-kafka[Getting started with {product-long-kafka}]
 * link:./docs/kafka/rhoas-cli-getting-started-kafka[Getting started with the `rhoas` CLI for {product-long-kafka}]
 * link:./docs/kafka/quarkus-kafka[Using Quarkus applications with Kafka instances in {product-long-kafka}]
-* link:./docs/kafka/kcat-kafka[Using Kafkacat with Kafka instances in {product-long-kafka}]
+* link:./docs/kafka/kcat-kafka[Configuring and connecting Kafkacat with {product-long-kafka}]
 * link:./docs/kafka/kafka-bin-scripts-kafka[Configuring and connecting Kafka scripts with {product-long-kafka}]
 * link:./docs/kafka/access-mgmt-kafka[Managing account access in {product-long-kafka}]
 * link:./docs/kafka/service-binding-kafka[Binding OpenShift applications to {product-long-kafka}]

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@
 
 == Common guides
 
-* link:./docs/rhoas/rhoas-cli-installation[Installing and configuring the `rhoas` CLI]
+* link:./docs/rhoas/rhoas-cli-installation[Installing and configuring the rhoas CLI]
 
 == Application examples used in guides
 

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@
 * link:./docs/kafka/rhoas-cli-getting-started-kafka[Getting started with the `rhoas` CLI for {product-long-kafka}]
 * link:./docs/kafka/quarkus-kafka[Using Quarkus applications with Kafka instances in {product-long-kafka}]
 * link:./docs/kafka/kcat-kafka[Using Kafkacat with Kafka instances in {product-long-kafka}]
-* link:./docs/kafka/kafka-bin-scripts-kafka[Using Kafka bin scripts with {product-long-kafka}]
+* link:./docs/kafka/kafka-bin-scripts-kafka[Configuring and connecting Kafka scripts with {product-long-kafka}]
 * link:./docs/kafka/access-mgmt-kafka[Managing account access in {product-long-kafka}]
 * link:./docs/kafka/service-binding-kafka[Binding OpenShift applications to {product-long-kafka}]
 * link:./docs/kafka/topic-configuration-kafka[Configuring topics in {product-long-kafka}]

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@
 
 * link:./docs/registry/getting-started-registry/[Getting started with {product-long-registry}]
 * link:./docs/registry/access-mgmt-registry[Managing account access in {product-long-registry}]
-* link:./docs/registry/rhoas-cli-registry[Getting started with the `rhoas` CLI for {product-long-registry}]
+* link:./docs/registry/rhoas-cli-registry[Getting started with the rhoas CLI for {product-long-registry}]
 * link:./docs/registry/quarkus-registry[Using Quarkus applications with Kafka instances and {product-long-registry} instances]
 
 == Common guides


### PR DESCRIPTION
Cleans up project readme files - fixes broken links, adds missing links and attributes on:

- https://github.com/redhat-developer/app-services-guides
- https://github.com/redhat-developer/app-services-guides/blob/main/CONTRIBUTING.adoc