### PR TITLE
Fix grafana step

### DIFF
--- a/docs/kafka/metrics-monitoring-kafka/README.adoc
+++ b/docs/kafka/metrics-monitoring-kafka/README.adoc
@@ -172,8 +172,12 @@ This procedure follows the https://prometheus.io/docs/prometheus/latest/configur
 ----
 
 The new scrape target becomes available after the configuration has reloaded.
-
-You can view your collected metrics in the Prometheus expression browser at `http://__<host>__:__<port>__/graph`, or integrate your Prometheus data source with a data-graphing tool such as Grafana. For information about Prometheus metrics in Grafana, see https://prometheus.io/docs/visualization/grafana/[Grafana Support for Prometheus] in the Grafana documentation.
+--
+. View your collected metrics in the Prometheus expression browser at `http://__<host>__:__<port>__/graph`, or integrate your Prometheus data source with a data-graphing tool such as Grafana. For information about Prometheus metrics in Grafana, see https://prometheus.io/docs/visualization/grafana/[Grafana Support for Prometheus] in the Grafana documentation.
++
+--
+If you use Grafana with your Prometheus instance, you can import the predefined https://grafana.com/grafana/dashboards/15835[{product-long-kafka} Grafana dashboard] to set up your metrics display. For import instructions, see https://grafana.com/docs/grafana/v7.5/dashboards/export-import/#importing-a-dashboard[Importing a dashboard] in the Grafana documentation.
+--
 
 When you create a Kafka instance and add new topics, the metrics are initially empty. After you start producing and consuming messages in your services, you can return to your monitoring tool to view related metrics. For example, to use Kafka scripts to produce and consume messages, see {base-url}{kafka-bin-scripts-url-kafka}[_Configuring and connecting Kafka scripts with {product-long-kafka}_^].
 
@@ -220,7 +224,6 @@ spec:
 ====
 
 --
-. In the Prometheus instance that you previously installed in your monitoring environment, import the predefined https://grafana.com/grafana/dashboards/15835[{product-long-kafka} Grafana dashboard] to set up your metrics display. For import instructions, see https://grafana.com/docs/grafana/v7.5/dashboards/export-import/#importing-a-dashboard[Importing a dashboard] in the Grafana documentation.
 
 [role="_additional-resources"]
 .Additional resources

--- a/docs/kafka/metrics-monitoring-kafka/README.adoc
+++ b/docs/kafka/metrics-monitoring-kafka/README.adoc
@@ -223,8 +223,6 @@ spec:
 ----
 ====
 
---
-
 [role="_additional-resources"]
 .Additional resources
 * {base-url}{getting-started-url-kafka}[_Getting started with {product-long-kafka}_^]


### PR DESCRIPTION
Fix step about grafana in metrics instructions.

@wtrocki can you re-review and re-approve? Here's the [doc preview](http://file.rdu.redhat.com/~sterobin/JK-7753/README.html#proc-configuring-metrics-prometheus_monitoring-metrics). I spoke with @DuncanDoyle and he pointed out that what was here before wasn't technically correct (the grafana dashboard of course isn't imported in prometheus but in grafana). Anyway, I fixed it and moved things around slightly to make more sense, and Duncan approved. If you agree, can you approve this PR so we can merge to fix it? Thanks.