### PR TITLE
docs(cli): update cli guides with contexts

### DIFF
--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -71,6 +71,7 @@ This guide describes how to get started quickly by doing the following:
 * {base-url}{rhoas-cli-getting-started-url-kafka}#proc-creating-service-account-cli_getting-started-rhoas-kafka[Create a service account]
 * {base-url}{rhoas-cli-getting-started-url-kafka}#proc-creating-kafka-topic-cli_getting-started-rhoas-kafka[Create a Kafka topic]
 * {base-url}{rhoas-cli-getting-started-url-kafka}#proc-commands-managing-kafka_getting-started-rhoas-kafka[Use `rhoas` to manage your Kafka instances, service accounts, and Kafka topics]
+* {base-url}{rhoas-cli-getting-started-url-kafka}#proc-generating-kafka-configs-cli_getting-started-rhoas-kafka[Generate configurations for a Kafka instance]
 
 //Additional line break to resolve mod docs generation error
 
@@ -105,6 +106,9 @@ This example creates a Kafka instance called `my-kafka`.
 $ rhoas kafka create --name my-kafka
 ----
 
+CLI uses service contexts to group service instances against which commands are executed.
+The created Kafka instance is set automatically in the current context.
+
 [NOTE]
 ====
 If you do not want to use the default values,
@@ -119,17 +123,14 @@ You will be prompted to enter the `Name`, `Cloud Provider`, and `Cloud Region` f
 .Reviewing details of a Kafka instance
 [source,shell]
 ----
-$ rhoas status kafka
+$ rhoas context status kafka
 ----
 
-This command shows that the Kafka instance is ready to use,
-because the `Status` field is `ready`.
 
 [NOTE]
 ====
-When you created the Kafka instance, it was set as the current instance automatically.
 If you have multiple Kafka instances,
-you can switch to a different instance by using the `rhoas kafka use` command.
+you can make the current context switch to a different instance by using the `rhoas context use-kafka` command.
 ====
 --
 
@@ -208,7 +209,7 @@ After creating a Kafka instance, you can create Kafka topics to start producing 
 
 [NOTE]
 ====
-You can use `rhoas kafka list` and `rhoas kafka use` to switch to a specific Kafka instance.
+You can use `rhoas kafka list` and `rhoas context use-kafka` to switch to a specific Kafka instance.
 
 .List Kafka instances
 [source,shell]
@@ -218,7 +219,7 @@ $ rhoas kafka list
 .Selecting a Kafka instance to use
 [source,shell]
 ----
-$ rhoas kafka use --name my-kafka
+$ rhoas context use-kafka --name my-kafka
 ----
 ====
 
@@ -244,6 +245,44 @@ For more information, use the command help `rhoas kafka topic create -h`.
 --
 
 . If necessary, you can edit or delete the topic by using the `rhoas kafka topic update` and `rhoas kafka topic delete` commands.
+
+[id="proc-genearting-kafka-configs-cli_{context}"]
+== Generating configurations for Kafka instance
+
+[role="_abstract"]
+After creating a Kafka instance, you can generate configurations to connect to the Kafka instance from your applications.
+
+.Prerequisites
+
+* You've created a Kafka instance, and it has a `ready` status.
+* The Kafka instance is set in the current context.
+* User and org have quota for creating service accounts
+
+.Procedure
+
+. Generate configurations for the current service context
++
+--
+This example generates a JSON file with configurations for the Kafka instance
+
+.Creating a Kafka topic with default values
+[source,shell]
+----
+$ rhoas generate-config --type json
+----
+--
+
+. Configurations can be generated for specified service context using the name flag
++
+--
+This example generates configurations for a context not set as current
+
+[source,shell]
+----
+$ rhoas generate-config --name my-context --type json
+----
+
+--
 
 [id="proc-commands-managing-kafka_{context}"]
 == Commands for managing Kafka

--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -256,15 +256,16 @@ After creating a Kafka instance, you can generate a configuration file that your
 
 * You've created a Kafka instance, and it has a `ready` status.
 * The Kafka instance is set in the current context.
-* User and org have quota for creating service accounts
+* Your user account and org have quota for creating service accounts.
 
 .Procedure
 
-. Generate configurations for the current service context
+* Generate a configuration file for the current service context.
 +
 --
-This example generates a JSON file with configurations for the Kafka instance
+This example generates a JSON file with configurations for the Kafka instance you created.
 
+. Generating a configuration file
 [source,shell]
 ----
 $ rhoas generate-config --type json

--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -265,7 +265,6 @@ After creating a Kafka instance, you can generate configurations to connect to t
 --
 This example generates a JSON file with configurations for the Kafka instance
 
-.Creating a Kafka topic with default values
 [source,shell]
 ----
 $ rhoas generate-config --type json

--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -247,10 +247,10 @@ For more information, use the command help `rhoas kafka topic create -h`.
 . If necessary, you can edit or delete the topic by using the `rhoas kafka topic update` and `rhoas kafka topic delete` commands.
 
 [id="proc-genearting-kafka-configs-cli_{context}"]
-== Generating configurations for Kafka instance
+== Generating configurations for a Kafka instance
 
 [role="_abstract"]
-After creating a Kafka instance, you can generate configurations to connect to the Kafka instance from your applications.
+After creating a Kafka instance, you can generate a configuration file that your applications can use to connect to your Kafka instance.
 
 .Prerequisites
 

--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -271,17 +271,6 @@ $ rhoas generate-config --type json
 ----
 --
 
-. Configurations can be generated for specified service context using the name flag
-+
---
-This example generates configurations for a context not set as current
-
-[source,shell]
-----
-$ rhoas generate-config --name my-context --type json
-----
-
---
 
 [id="proc-commands-managing-kafka_{context}"]
 == Commands for managing Kafka

--- a/docs/registry/rhoas-cli-getting-started-registry/README.adoc
+++ b/docs/registry/rhoas-cli-getting-started-registry/README.adoc
@@ -74,6 +74,7 @@ You can get started with {product-long-registry} by doing the following tasks:
 * {base-url}{rhoas-cli-getting-started-url-registry}#proc-downloading-service-registry-artifacts_getting-started-rhoas-service-registry[Download {registry} artifacts]
 * {base-url}{rhoas-cli-getting-started-url-registry}#proc-updating-service-registry-artifacts_getting-started-rhoas-service-registry[Update {registry} artifacts]
 * {base-url}{rhoas-cli-getting-started-url-registry}#proc-configuring-service-registry-rules_getting-started-rhoas-service-registry[Configure {registry} rules]
+* {base-url}{rhoas-cli-getting-started-url-registry}#proc-generating-registry-configs_getting-started-rhoas-service-registry[Generating {registry} configurations]
 * {base-url}{rhoas-cli-getting-started-url-registry}#proc-commands-managing-registry_getting-started-rhoas-service-registry[Use `rhoas` to manage your {registry} instance, service accounts, and artifacts]
 
 //Additional line break to resolve mod docs generation error
@@ -107,6 +108,9 @@ This example creates a {registry} instance called `my-registry`.
 $ rhoas service-registry create --name my-registry
 ----
 
+CLI uses service contexts to group service instances against which commands are executed.
+The created {registry} instance is set automatically in the current context.
+
 [NOTE]
 ====
 If you do not want to use the default values,
@@ -121,7 +125,7 @@ You are prompted to enter the `Name` for the {registry} instance.
 .Reviewing details of a {registry} instance
 [source,shell]
 ----
-$ rhoas status service-registry
+$ rhoas context status service-registry
 ----
 
 This command shows that the {registry} instance is ready to use,
@@ -129,9 +133,8 @@ because the `Status` field is `ready`.
 
 [NOTE]
 ====
-When you created the {registry} instance, it was set as the current instance automatically.
 If you have multiple {registry} instances,
-you can switch to a different instance by using the `rhoas service-registry use` command.
+you can make the current context switch to a different instance by using the `rhoas context use-service-registry` command.
 ====
 --
 
@@ -213,12 +216,12 @@ Artifacts might include, for example, schemas that define the structure of Kafka
 
 [NOTE]
 ====
-You can use `rhoas service-registry use` to switch to a specific {registry} instance.
+You can use `rhoas context use-service-registry` to switch to a specific {registry} instance.
 
 .Selecting a {registry} instance to use
 [source,shell]
 ----
-$ rhoas service-registry use --name=my-registry
+$ rhoas context use-service-registry --name=my-registry
 ----
 ====
 
@@ -475,6 +478,42 @@ You can use additional options, such as `--group` and `--instance-id`, to specif
 For more information about any of the options, view the command help `rhoas service-registry rule -h`.
 ====
 
+[id="proc-generating-registry-configs_{context}"]
+== Generating configurations for Service Registry instance
+
+[role="_abstract"]
+After creating a Service Registry instance, you can generate configurations to connect to the Service Registry instance from your applications.
+
+.Prerequisites
+
+* You've created a Service Registry instance.
+* The Service Registry instance is set in the current context.
+* User and org have quota for creating service accounts
+
+.Procedure
+
+. Generate configurations for the current service context
++
+--
+This example generates a JSON file with configurations for the Service Registry instance
+
+[source,shell]
+----
+$ rhoas generate-config --type json
+----
+--
+
+. Configurations can be generated for specified service context using the name flag
++
+--
+This example generates configurations for a context not set as current
+
+[source,shell]
+----
+$ rhoas generate-config --name my-context --type json
+----
+
+--
 
 [id="proc-commands-managing-registry_{context}"]
 == Commands for managing {registry}

--- a/docs/registry/rhoas-cli-getting-started-registry/README.adoc
+++ b/docs/registry/rhoas-cli-getting-started-registry/README.adoc
@@ -108,7 +108,7 @@ This example creates a {registry} instance called `my-registry`.
 $ rhoas service-registry create --name my-registry
 ----
 
-CLI uses service contexts to group service instances against which commands are executed.
+The CLI uses service contexts to group service instances against which commands are executed.
 The created {registry} instance is set automatically in the current context.
 
 [NOTE]
@@ -134,7 +134,7 @@ because the `Status` field is `ready`.
 [NOTE]
 ====
 If you have multiple {registry} instances,
-you can make the current context switch to a different instance by using the `rhoas context use-service-registry` command.
+you can change the context to a different instance by using the `rhoas context use-service-registry` command.
 ====
 --
 
@@ -482,21 +482,22 @@ For more information about any of the options, view the command help `rhoas serv
 == Generating configurations for Service Registry instance
 
 [role="_abstract"]
-After creating a Service Registry instance, you can generate configurations to connect to the Service Registry instance from your applications.
+After creating a Service Registry instance, you can generate a configuration file that your applications can use to connect to your Service Registry instance.
 
 .Prerequisites
 
 * You've created a Service Registry instance.
 * The Service Registry instance is set in the current context.
-* User and org have quota for creating service accounts
+* Your user account and org have quota for creating service accounts.
 
 .Procedure
 
-. Generate configurations for the current service context
+* Generate a configuration file for the current service context.
 +
 --
-This example generates a JSON file with configurations for the Service Registry instance
+This example generates a JSON file with configurations for the Service Registry instance.
 
+.Generating a configuration file
 [source,shell]
 ----
 $ rhoas generate-config --type json

--- a/docs/registry/rhoas-cli-getting-started-registry/README.adoc
+++ b/docs/registry/rhoas-cli-getting-started-registry/README.adoc
@@ -503,17 +503,6 @@ $ rhoas generate-config --type json
 ----
 --
 
-. Configurations can be generated for specified service context using the name flag
-+
---
-This example generates configurations for a context not set as current
-
-[source,shell]
-----
-$ rhoas generate-config --name my-context --type json
-----
-
---
 
 [id="proc-commands-managing-registry_{context}"]
 == Commands for managing {registry}


### PR DESCRIPTION
Modify CLI guides to include context commands while working with services.

To be merged after #448 .