### PR TITLE
Add purchasing additional resource to GS quick start

### DIFF
--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -307,6 +307,7 @@ endif::[]
 
 [role="_additional-resources"]
 == Additional resources
+* https://console.redhat.com/application-services/streams/overview[Purchase a subscription to {product-long-kafka}]
 * https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1/guide/7d28aec8-e146-44db-a4a5-fafc1f426ca5[_Configuring topics in {product-long-kafka}_^]
 * {base-url}{rhoas-cli-getting-started-url-kafka}[_Getting started with the `rhoas` CLI for {product-long-kafka}_^]
 * {rhoas-cli-base-url}{rhoas-cli-ref-url}[_CLI command reference (rhoas)_^]


### PR DESCRIPTION
Added an additional resource to the Kafka GS quick start to point users to the Kafka Overview page that contains the info about how to purchase a subscription. 

As an additional resource, this won't show up in the quick start itself (the additional resources are only included in the customer portal version). I don't see a great way to add the pointer to the purchasing info to the quick start itself. The conclusion would probably be the best place, but it's already got a fair amount going on.