### PR TITLE
Use token endpoint apicurio serdes

### DIFF
--- a/code-examples/quarkus-service-registry-quickstart/consumer/pom.xml
+++ b/code-examples/quarkus-service-registry-quickstart/consumer/pom.xml
@@ -14,14 +14,15 @@
 
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>2.2.3.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.2.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.8.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
         <testcontainers.version>1.15.2</testcontainers.version>
+        <apicurio-common-rest-client.version>0.1.9.Final</apicurio-common-rest-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -46,6 +47,17 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-apicurio-registry-avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>apicurio-common-rest-client-vertx</artifactId>
+                    <groupId>io.apicurio</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-common-rest-client-vertx</artifactId>
+            <version>${apicurio-common-rest-client.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -58,7 +70,6 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
-            <version>0.8.1</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/code-examples/quarkus-service-registry-quickstart/consumer/src/main/resources/application.properties
+++ b/code-examples/quarkus-service-registry-quickstart/consumer/src/main/resources/application.properties
@@ -4,8 +4,7 @@ mp.messaging.incoming.quotes.value.deserializer=io.apicurio.registry.serde.avro.
 mp.messaging.incoming.quotes.apicurio.registry.use-specific-avro-reader=true
 mp.messaging.incoming.quotes.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
 
-%dev.mp.messaging.incoming.quotes.apicurio.auth.service.url=${OAUTH_SERVER_URL:https://identity.api.openshift.com/auth}
-%dev.mp.messaging.incoming.quotes.apicurio.auth.realm=${OAUTH_REALM:rhoas}
+%dev.mp.messaging.incoming.quotes.apicurio.auth.service.token.endpoint=${OAUTH_TOKEN_ENDPOINT_URI:https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token}
 %dev.mp.messaging.incoming.quotes.apicurio.auth.client.id=${CLIENT_ID}
 %dev.mp.messaging.incoming.quotes.apicurio.auth.client.secret=${CLIENT_SECRET}
 

--- a/code-examples/quarkus-service-registry-quickstart/producer/pom.xml
+++ b/code-examples/quarkus-service-registry-quickstart/producer/pom.xml
@@ -14,14 +14,15 @@
 
     <properties>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <quarkus-plugin.version>2.2.3.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.2.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.8.0.Final</quarkus.platform.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
         <testcontainers.version>1.15.2</testcontainers.version>
+        <apicurio-common-rest-client.version>0.1.9.Final</apicurio-common-rest-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -46,6 +47,17 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-apicurio-registry-avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>apicurio-common-rest-client-vertx</artifactId>
+                    <groupId>io.apicurio</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-common-rest-client-vertx</artifactId>
+            <version>${apicurio-common-rest-client.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -58,7 +70,6 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
-            <version>0.8.1</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/code-examples/quarkus-service-registry-quickstart/producer/src/main/resources/application.properties
+++ b/code-examples/quarkus-service-registry-quickstart/producer/src/main/resources/application.properties
@@ -10,8 +10,7 @@ mp.messaging.outgoing.quotes.value.serializer=io.apicurio.registry.serde.avro.Av
 mp.messaging.outgoing.quotes.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.quotes.merge=true
 
-%dev.mp.messaging.outgoing.quotes.apicurio.auth.realm=${OAUTH_REALM:rhoas}
-%dev.mp.messaging.outgoing.quotes.apicurio.auth.service.url=${OAUTH_SERVER_URL:https://identity.api.openshift.com/auth}
+%dev.mp.messaging.outgoing.quotes.apicurio.auth.service.token.endpoint=${OAUTH_TOKEN_ENDPOINT_URI:https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token}
 %dev.mp.messaging.outgoing.quotes.apicurio.auth.client.id=${CLIENT_ID}
 %dev.mp.messaging.outgoing.quotes.apicurio.auth.client.secret=${CLIENT_SECRET}
 

--- a/code-examples/quarkus-service-registry-quickstart/producer/src/main/resources/application.properties
+++ b/code-examples/quarkus-service-registry-quickstart/producer/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 # Configure the outgoing `quotes` Kafka topic
 mp.messaging.outgoing.quotes.apicurio.registry.auto-register=true
 mp.messaging.outgoing.quotes.apicurio.registry.find-latest=true
-mp.messaging.outgoing.quotes.apicurio.registry.artifact-resolver-strategy=io.apicurio.registry.serde.avro.strategy.TopicRecordIdStrategy
+mp.messaging.outgoing.quotes.apicurio.registry.artifact-resolver-strategy=io.apicurio.registry.serde.strategy.TopicIdStrategy
 mp.messaging.outgoing.quotes.apicurio.registry.avro-datum-provider=io.apicurio.registry.serde.avro.ReflectAvroDatumProvider
 mp.messaging.outgoing.quotes.connector=smallrye-kafka
 mp.messaging.outgoing.quotes.value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer


### PR DESCRIPTION
This PR addresses two things:

- Use token endpoint instead of auth URL + realm.
- Update Quarkus version used in example.