### PR TITLE
Fix command block title in Kafka RHOAS CLI getting started guide

### DIFF
--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -265,13 +265,12 @@ After creating a Kafka instance, you can generate a configuration file that your
 --
 This example generates a JSON file with configurations for the Kafka instance you created.
 
-. Generating a configuration file
+.Generating a configuration file
 [source,shell]
 ----
 $ rhoas generate-config --type json
 ----
 --
-
 
 [id="proc-commands-managing-kafka_{context}"]
 == Commands for managing Kafka


### PR DESCRIPTION
@jbyrne-redhat Got another really minor fix that needs to be reviewed. In this case, there's just a mis-formatted code-block title.