### PR TITLE
docs: change cli guides with updated command names

### DIFF
--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -130,7 +130,7 @@ $ rhoas context status kafka
 [NOTE]
 ====
 If you have multiple Kafka instances,
-you can make the current context switch to a different instance by using the `rhoas context use-kafka` command.
+you can make the current context switch to a different instance by using the `rhoas context set-kafka` command.
 ====
 --
 
@@ -209,7 +209,7 @@ After creating a Kafka instance, you can create Kafka topics to start producing 
 
 [NOTE]
 ====
-You can use `rhoas kafka list` and `rhoas context use-kafka` to switch to a specific Kafka instance.
+You can use `rhoas kafka list` and `rhoas context set-kafka` to switch to a specific Kafka instance.
 
 .List Kafka instances
 [source,shell]
@@ -219,7 +219,7 @@ $ rhoas kafka list
 .Selecting a Kafka instance to use
 [source,shell]
 ----
-$ rhoas context use-kafka --name my-kafka
+$ rhoas context set-kafka --name my-kafka
 ----
 ====
 

--- a/docs/registry/rhoas-cli-getting-started-registry/README.adoc
+++ b/docs/registry/rhoas-cli-getting-started-registry/README.adoc
@@ -134,7 +134,7 @@ because the `Status` field is `ready`.
 [NOTE]
 ====
 If you have multiple {registry} instances,
-you can change the context to a different instance by using the `rhoas context use-service-registry` command.
+you can change the context to a different instance by using the `rhoas context set-service-registry` command.
 ====
 --
 
@@ -216,12 +216,12 @@ Artifacts might include, for example, schemas that define the structure of Kafka
 
 [NOTE]
 ====
-You can use `rhoas context use-service-registry` to switch to a specific {registry} instance.
+You can use `rhoas context set-service-registry` to switch to a specific {registry} instance.
 
 .Selecting a {registry} instance to use
 [source,shell]
 ----
-$ rhoas context use-service-registry --name=my-registry
+$ rhoas context set-service-registry --name=my-registry
 ----
 ====
 


### PR DESCRIPTION
Documentation has been updated as certain context sub-commands were renamed.

`rhoas context use-kafka` => `rhoas context set-kafka`
`rhoas context use-service-registry` => `rhoas context set-service-registry`

For [app-services-cli/1542](https://github.com/redhat-developer/app-services-cli/pull/1542)