### PR TITLE
fix: issues with kcat guide

### DIFF
--- a/docs/kafka/kcat-kafka/README.adoc
+++ b/docs/kafka/kcat-kafka/README.adoc
@@ -166,7 +166,7 @@ $ kafkacat -t my-first-kafka-topic -b "$KAFKA_HOST" \
 
 NOTE: {product-kafka} also supports the SASL/OAUTHBEARER mechanism for authentication, which is the recommended authentication mechanism to use. However, Kafkacat does not yet fully support OAUTHBEARER, so this example uses SASL/PLAIN.
 
-NOTE: kafkacat producer might behave differently depending on the operating system. For Mac operating systems messages can be sent by redirecting them to the kafkacat binary. For example "echo "message" | kafkacat ... " 
+NOTE: A Kafkacat producer might behave differently depending on the operating system. For example, on Mac operating systems, messages are sent by redirecting them to the Kafkacat binary in the format `echo "message" | kafkacat ...`.
 
 --
 . With Kafkacat running in producer mode, enter messages into Kafkacat that you want to produce to the Kafka topic.

--- a/docs/kafka/kcat-kafka/README.adoc
+++ b/docs/kafka/kcat-kafka/README.adoc
@@ -166,8 +166,7 @@ $ kafkacat -t my-first-kafka-topic -b "$KAFKA_HOST" \
 
 NOTE: {product-kafka} also supports the SASL/OAUTHBEARER mechanism for authentication, which is the recommended authentication mechanism to use. However, Kafkacat does not yet fully support OAUTHBEARER, so this example uses SASL/PLAIN.
 
-NOTE: kafkacat producer might behave differently depending on the operating system. For Mac operating systems 
-messages can be sent using pipe. For example "echo "message" | kcat ... " 
+NOTE: kafkacat producer might behave differently depending on the operating system. For Mac operating systems messages can be sent by redirecting them to the kafkacat binary. For example "echo "message" | kafkacat ... " 
 
 --
 . With Kafkacat running in producer mode, enter messages into Kafkacat that you want to produce to the Kafka topic.

--- a/docs/kafka/kcat-kafka/README.adoc
+++ b/docs/kafka/kcat-kafka/README.adoc
@@ -112,6 +112,8 @@ For more information about Kafkacat configuration options, see https://github.co
 
 NOTE: Kafkacat does not yet fully support SASL/OAUTHBEARER authentication, so connecting to a Kafka instance requires only the bootstrap server and the service account credentials for SASL/PLAIN authentication.
 
+NOTE: Kafkacat have been recently renamed to kcat. If you use latest version of kafkacat please replace all occurences referencing kafkacat binary to kcat 
+
 .Prerequisites
 ifndef::qs[]
 * You have the bootstrap server endpoint for your Kafka instance. To relocate the server endpoint, select your Kafka instance in the {product-kafka} web console, select the options menu (three vertical dots), and click *Connection*.
@@ -163,6 +165,9 @@ $ kafkacat -t my-first-kafka-topic -b "$KAFKA_HOST" \
 ----
 
 NOTE: {product-kafka} also supports the SASL/OAUTHBEARER mechanism for authentication, which is the recommended authentication mechanism to use. However, Kafkacat does not yet fully support OAUTHBEARER, so this example uses SASL/PLAIN.
+
+NOTE: kafkacat producer might behave differently depending on the operating system. For Mac operating systems 
+messages can be sent using pipe. For example "echo "message" | kcat ... " 
 
 --
 . With Kafkacat running in producer mode, enter messages into Kafkacat that you want to produce to the Kafka topic.


### PR DESCRIPTION
Reports have been made about missing binary name and also kcat not working at all (no messages produced on mac).
We need to make this guide functional for the summit. Any improvements appreciated.