### PR TITLE
Unhide service registry getting started quick start

### DIFF
--- a/docs/registry/getting-started-registry/quickstart.yml
+++ b/docs/registry/getting-started-registry/quickstart.yml
@@ -3,7 +3,7 @@ kind: QuickStarts
 metadata:
   name: getting-started-service-registry
   annotations:
-    draft: true
+    draft: false
     order: 1
 spec:
   version: 0.1


### PR DESCRIPTION
Make Service Registry quick start visible again by setting draft status to false