### PR TITLE
Update completion command for Fish shell

### DIFF
--- a/docs/rhoas/rhoas-cli-installation/README.adoc
+++ b/docs/rhoas/rhoas-cli-installation/README.adoc
@@ -303,7 +303,7 @@ Command completion is enabled.
 +
 [source,shell]
 ----
-$ rhoas completion -s fish > ~/.config/fish/completions/rhoas.fish
+$ rhoas completion fish > ~/.config/fish/completions/rhoas.fish
 ----
 
 . Open a new terminal window.


### PR DESCRIPTION
With newest version (rhoas version 0.42.2), the `-s` option no longer exists. Other shells  have already dropped the `-s` but it looks like Fish was overlooked.