### PR TITLE
Fix sect ID causing broken link

### DIFF
--- a/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
+++ b/docs/kafka/rhoas-cli-getting-started-kafka/README.adoc
@@ -250,7 +250,7 @@ For more information, use the command help `rhoas kafka topic create -h`.
 
 . If necessary, you can edit or delete the topic by using the `rhoas kafka topic update` and `rhoas kafka topic delete` commands.
 
-[id="proc-genearting-kafka-configs-cli_{context}"]
+[id="proc-generating-kafka-configs-cli_{context}"]
 == Generating configurations for a Kafka instance
 
 [role="_abstract"]


### PR DESCRIPTION
The existing sect ID was causing a broken link in the hand-created "TOC" at the top of the guide.