### PR TITLE
Add notes for topic partition error situation

### DIFF
--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -314,7 +314,9 @@ image::sak-create-topic.png[Image of wizard to create a topic]
 
 After you complete the topic setup, the new Kafka topic is listed in the topics table. You can now start producing and consuming messages to and from this topic using services that you connect to this instance.
 
-NOTE: If your topic creation is unsuccessful and you receive an error message, try to create your topic again later. This situation might occur, for example, if your selected cloud provider has a temporary availability problem that affects your Kafka instance.
+NOTE: If you try to create a topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[Red Hat OpenShift Streams for Apache Kafka service limits].
+
+NOTE: If the topic creation is unsuccessful and you see a `400 Bad Request` error message, try to create your topic again later. This situation might occur, for example, if your selected cloud provider has a temporary availability problem that affects your Kafka instance.
 
 --
 . In the topics table, on the right side of the Kafka topic, use the options icon (three vertical dots) to edit or delete the topic as needed.

--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -127,7 +127,7 @@ NOTE: The cloud provider is preconfigured.
 ////
 . If you've purchased a subscription for {product-kafka}, use the slider to select an instance size. Instances with more streaming units have more capacity.
 +
-NOTE: In {product-kafka}, you can create Kafka instances of 1 or 2 streaming units. Instances larger than 1 streaming unit are currently available only as a Technology Preview and should not be used in production. If you're creating a trial instance, the instance size is preconfigured.
+NOTE: In {product-kafka}, you can create Kafka instances of 1 or 2 streaming units. However, instances larger than 1 streaming unit are currently available only as a Technology Preview and should not be used in production. If you're creating a trial instance, the instance size is preconfigured.
 
 
 . Click *Create instance* to start the creation process for your Kafka instance.
@@ -314,7 +314,9 @@ image::sak-create-topic.png[Image of wizard to create a topic]
 
 After you complete the topic setup, the new Kafka topic is listed in the topics table. You can now start producing and consuming messages to and from this topic using services that you connect to this instance.
 
-NOTE: If you try to create a topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[Red Hat OpenShift Streams for Apache Kafka service limits].
+ifndef::community[]
+NOTE: If you try to create a topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[{product-long-kafka} service limits].
+endif::[]
 
 NOTE: If the topic creation is unsuccessful and you see a `400 Bad Request` error message, try to create your topic again later. This situation might occur, for example, if your selected cloud provider has a temporary availability problem that affects your Kafka instance.
 

--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -127,7 +127,7 @@ NOTE: The cloud provider is preconfigured.
 ////
 . If you've purchased a subscription for {product-kafka}, use the slider to select an instance size. Instances with more streaming units have more capacity.
 +
-NOTE: In {product-kafka}, you can create Kafka instances of 1 or 2 streaming units. However, instances larger than 1 streaming unit are currently available only as a Technology Preview and should not be used in production. If you're creating a trial instance, the instance size is preconfigured.
+NOTE: In {product-kafka}, you can create Kafka instances of 1 or 2 streaming units. Instances larger than 1 streaming unit are currently available only as a Technology Preview and should not be used in production. If you're creating a trial instance, the instance size is preconfigured.
 
 
 . Click *Create instance* to start the creation process for your Kafka instance.

--- a/docs/kafka/kafka-bin-scripts-kafka/README.adoc
+++ b/docs/kafka/kafka-bin-scripts-kafka/README.adoc
@@ -188,7 +188,9 @@ Created topic my-other-topic.
 +
 The preceding example uses the `kafka-topics` script to create the `my-other-topic` Kafka topic with the default settings.
 +
-NOTE: If you try to create a topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[Red Hat OpenShift Streams for Apache Kafka service limits].
+ifndef::community[]
+NOTE: If you try to create a topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[{product-long-kafka} service limits].
+endif::[]
 
 . Enter the following command to start the `kafka-console-producer` script.
 +

--- a/docs/kafka/kafka-bin-scripts-kafka/README.adoc
+++ b/docs/kafka/kafka-bin-scripts-kafka/README.adoc
@@ -187,6 +187,8 @@ Created topic my-other-topic.
 --
 +
 The preceding example uses the `kafka-topics` script to create the `my-other-topic` Kafka topic with the default settings.
++
+NOTE: If you try to create a topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[Red Hat OpenShift Streams for Apache Kafka service limits].
 
 . Enter the following command to start the `kafka-console-producer` script.
 +

--- a/docs/kafka/topic-configuration-kafka/README.adoc
+++ b/docs/kafka/topic-configuration-kafka/README.adoc
@@ -173,7 +173,13 @@ h|Kafka property name
 |`num.partitions`
 |===
 
-NOTE: If you try to create a new topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. If you try to increase the number of partitions for an existing topic and this would cause the cause the partition limit of the Kafka instance to be exceeded, you see an error message stating that topic authorization failed. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[Red Hat OpenShift Streams for Apache Kafka service limits].
+ifdef::community[]
+NOTE: If you try to create a new topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. If you try to increase the number of partitions for an existing topic and this would cause the cause the partition limit of the Kafka instance to be exceeded, you see an error message stating that topic authorization failed.
+endif::[]
+
+ifndef::community[]
+NOTE: If you try to create a new topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. If you try to increase the number of partitions for an existing topic and this would cause the cause the partition limit of the Kafka instance to be exceeded, you see an error message stating that topic authorization failed. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[{product-long-kafka} service limits].
+endif::[]
 --
 
 Replicas::

--- a/docs/kafka/topic-configuration-kafka/README.adoc
+++ b/docs/kafka/topic-configuration-kafka/README.adoc
@@ -172,6 +172,8 @@ h|Supported values
 h|Kafka property name
 |`num.partitions`
 |===
+
+NOTE: If you try to create a new topic with a number of partitions that would cause the partition limit of the Kafka instance to be exceeded, you see an error message indicating this. If you try to increase the number of partitions for an existing topic and this would cause the cause the partition limit of the Kafka instance to be exceeded, you see an error message stating that topic authorization failed. For more information about partition limits for Kafka instances, see https://access.redhat.com/articles/5979061[Red Hat OpenShift Streams for Apache Kafka service limits].
 --
 
 Replicas::


### PR DESCRIPTION
**Notes for reviewers**

 - For HTML previews of the notes added to the _Configuring topics_ and _Getting started_ guides, see [here](http://file.emea.redhat.com/~jbyrne/JK-8497/README.html#ref-supported-topic-properties_configuring-topics) and [here](http://file.emea.redhat.com/~jbyrne/JK-8497/README1.html#proc-creating-kafka-topic_getting-started).