### PR TITLE
Incorrect environment variables and env file name

### DIFF
--- a/docs/kafka/nodejs-kafka/README.adoc
+++ b/docs/kafka/nodejs-kafka/README.adoc
@@ -135,7 +135,7 @@ To enable your Node.js application to access a Kafka instance, you must configur
 * The generated credentials for your {product-kafka} service account
 * The Simple Authentication and Security Layer (SASL) mechanism that the client will use to authenticate with the Kafka instance
 
-In this task, you'll create a new configuration file called `rhoas.env`. In this file, you'll set the required bootstrap server and client credentials as environment variables.
+In this task, you'll create a new configuration file called `.env`. In this file, you'll set the required bootstrap server and client credentials as environment variables.
 
 .Prerequisites
 ifndef::qs[]
@@ -146,16 +146,16 @@ endif::[]
 
 .Procedure
 
-. In your IDE, create a new file. Save the file with the name `rhoas.env`, at the root level of the `reactive-example` directory for the cloned repository.
+. In your IDE, create a new file. Save the file with the name `.env`, at the root level of the `reactive-example` directory for the cloned repository.
 
-. In the `rhoas.env` file, add the lines shown in the example. These lines set the bootstrap server and client credentials as environment variables to be used by the Node.js application.
+. In the `.env` file, add the lines shown in the example. These lines set the bootstrap server and client credentials as environment variables to be used by the Node.js application.
 +
-.Setting environment variables in the rhoas.env file
+.Setting environment variables in the .env file
 [source,subs="+quotes"]
 ----
-KAFKA_HOST=__<bootstrap_server>__
-RHOAS_CLIENT_ID=__<client_id>__
-RHOAS_CLIENT_SECRET=__<client_secret>__
+KAFKA_BOOTSTRAP_SERVER=__<bootstrap_server>__
+KAFKA_CLIENT_ID=__<client_id>__
+KAFKA_CLIENT_SECRET=__<client_secret>__
 KAFKA_SASL_MECHANISM=plain
 ----
 +
@@ -173,7 +173,7 @@ endif::[]
 +
 In this case, observe that the Node.js application uses the SASL/PLAIN authentication method (that is, the value of `KAFKA_SASL_MECHANISM` is set to `plain`). This means that the application uses only the client ID and client secret to authenticate with the Kafka instance. The application doesn't require an authentication token.
 
-. Save the `rhoas.env` file.
+. Save the `.env` file.
 
 ifdef::qs[]
 .Verification
@@ -328,11 +328,11 @@ NOTE: You can also use the {product-long-kafka} web console to browse messages i
 
 . In your IDE, in the `producer-backend` directory of the repository that you cloned, open the `producer.js` file.
 +
-Observe that the producer component is configured to process environment variables from the `rhoas.env` file that you created. The component used the bootstrap server endpoint and client credentials stored in this file to connect to the Kafka instance.
+Observe that the producer component is configured to process environment variables from the `.env` file that you created. The component used the bootstrap server endpoint and client credentials stored in this file to connect to the Kafka instance.
 
 . In the `consumer-backend` directory, open the `consumer.js` file.
 +
-Observe that the consumer component is also configured to process environment variables from the `rhoas.env` file that you created.
+Observe that the consumer component is also configured to process environment variables from the `.env` file that you created.
 
 ifdef::qs[]
 .Verification


### PR DESCRIPTION
Just going through some of the guides node with Kafka and there were some issues.

The example code used in the example [here](https://github.com/nodeshift-starters/reactive-example) uses different environment variables for consumer and producer backends. The specific code examples are below.

- [Consumer](https://github.com/nodeshift-starters/reactive-example/blob/kafkajs/consumer-backend/consumer.js#L26-L32)
- [Producer](https://github.com/nodeshift-starters/reactive-example/blob/kafkajs/producer-backend/producer.js#L17-L23)

Also in the docs it mentions creating a file called `rhoas.env` this did not set the environment variables even in root or the working directory. Changing this to `.env` worked. 