### PR TITLE
chore: don't eagerly load dependencies

### DIFF
--- a/.build/webpack.common.js
+++ b/.build/webpack.common.js
@@ -129,17 +129,14 @@ module.exports = (env, argv) => {
         shared: {
           ...dependencies,
           react: {
-            eager: true,
             singleton: true,
             requiredVersion: dependencies["react"],
           },
           "react-dom": {
-            eager: true,
             singleton: true,
             requiredVersion: dependencies["react-dom"],
           },
           "@rhoas/app-services-ui-shared": {
-            eager: true,
             singleton: true,
             requiredVersion: dependencies["@rhoas/app-services-ui-shared"]
           },


### PR DESCRIPTION
remove all eager loading as we should never eagerly load any dependency ever; when eagerly loading, the dependency gets bundled with the bundle that will be loaded through module federation, forcing users to download them all over again