### PR TITLE
Updated Metrics and Messages guides according to agreed style guidelines

### DIFF
--- a/docs/kafka/message-browsing-kafka/README.adoc
+++ b/docs/kafka/message-browsing-kafka/README.adoc
@@ -86,9 +86,13 @@ ifdef::context[:parent-context: {context}]
 // Purpose statement for the assembly
 [role="_abstract"]
 
-As a developer or administrator, you can use the {product-long-kafka} web console to view and inspect messages for a Kafka topic. You might use this functionality, for example, to verify that a client is producing messages to the expected topic partition, that your topic is storing messages correctly, or that messages have the expected content.
+As a developer or administrator, you can use the {product-long-kafka} web console to view and inspect messages for a Kafka topic. You might use this functionality to verify the state of the following elements:
 
-When you select a topic in the console, you can use the *Messages* tab to view a list of messages for that topic. You can filter the list of messages in the following ways:
+* Clients are producing messages to the expected topic partition
+* Topics are storing messages correctly
+* Messages have the expected content
+
+When you select a topic in the web console, you can use the *Messages* tab to view a list of messages for that topic. You can filter the list of messages in the following ways:
 
 * Specify a partition and see messages sent to the partition.
 * Specify a partition and offset and see messages sent to the partition from that offset.
@@ -100,14 +104,14 @@ When you select a topic in the console, you can use the *Messages* tab to view a
 [id="proc-browsing-messages-for-a-topic_{context}"]
 == Browsing messages for a topic
 
-The following procedure shows how to filter and inspect a list of messages for a topic in the {product-kafka} web console.
+The following procedure shows how to filter and inspect a list of messages for a topic in the {product-long-kafka} web console.
 
 .Prerequisites
 
 * You have a Kafka instance with a topic that contains some messages. To learn how to create your _first_ Kafka instance and topic and then send messages to the topic that will appear on the *Messages* page, see the following guides:
 +
-** {base-url}{getting-started-url-kafka}[_Getting started with {product-long-kafka}_^]
-** {base-url}{kafka-bin-scripts-url-kafka}[_Configuring and connecting Kafka scripts with {product-long-kafka}_^]
+** {base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}^]
+** {base-url}{kafka-bin-scripts-url-kafka}[Configuring and connecting Kafka scripts with {product-long-kafka}^]
 
 .Procedure
 
@@ -143,22 +147,22 @@ Similarly, if a message is encoded (for example, in a format such as UTF-8 or Ba
 
 . To copy the full message value or header data, click the copy icon next to the data in the *Message* pane.
 
-. To see messages for a different topic partition, select a new value in the *Partition* drop-down menu.
+. To see messages for a different topic partition, select a new value in the *Partition* list.
 +
-NOTE: If you have many partitions, you can filter the list shown in the drop-down menu by typing a value in the field.
+NOTE: If you have many partitions, you can filter the values shown in the *Partition* list by typing a value in the field.
 
 . To further refine the list of messages in the table, use the filter controls at the top of the *Messages* page.
 +
 --
 * To filter messages by topic partition and offset, perform the following actions:
 ... In the *Partition* field, select a topic partition.
-... In the drop-down menu that shows a default value of `Offset`, keep this default value.
-... In the *Offset* field, type an offset value.
+... Click the arrow next to the default value of `Latest messages` and select `Offset` from the list.
+... In the *Specify offset* field, type an offset value.
 ... To apply your filter settings, click the search (magnifying glass) icon.
 
 * To filter messages by topic partition and date and time, perform the following actions:
 ... In the *Partition* field, select a topic partition.
-... In the drop-down menu that shows a default value of `Offset`, change the value to `Timestamp`.
+... Click the arrow next to the default value of `Latest messages` and select `Timestamp` from the list.
 +
 Additional selection tools appear.
 ... Use the additional selection tools to set date and time values. Alternatively, type a date and time value in the format shown in the field.
@@ -166,7 +170,7 @@ Additional selection tools appear.
 
 * To filter messages by topic partition and epoch timestamp, perform the following actions:
 ... In the *Partition* field, select a topic partition.
-... In the drop-down menu that shows a default value of `Offset`, change the value to `Epoch timestamp`.
+... Click the arrow next to the default value of `Latest messages` and select `Epoch timestamp` from the list.
 ... In the *Epoch timestamp* field, type or paste an epoch timestamp value.
 +
 NOTE: You can easily convert a human-readable date and time to an epoch value using a https://www.epochconverter.com/[timestamp conversion tool^].
@@ -174,9 +178,8 @@ NOTE: You can easily convert a human-readable date and time to an epoch value us
 
 --
 +
-Based on your filter settings, the *Messages* page automatically reloads the list of messsages in the table.
+Based on your filter settings, the *Messages* page automatically reloads the list of messages in the table.
 
-. To clear your existing offset, timestamp, or epoch timestamp selections and revert to seeing the latest messages in the selected partition, select `Latest messages` in the drop-down menu that has a default value of `Offset`.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/docs/kafka/message-browsing-kafka/README.adoc
+++ b/docs/kafka/message-browsing-kafka/README.adoc
@@ -86,11 +86,7 @@ ifdef::context[:parent-context: {context}]
 // Purpose statement for the assembly
 [role="_abstract"]
 
-As a developer or administrator, you can use the {product-long-kafka} web console to view and inspect messages for a Kafka topic. You might use this functionality to verify the state of the following elements:
-
-* Clients are producing messages to the expected topic partition
-* Topics are storing messages correctly
-* Messages have the expected content
+As a developer or administrator, you can use the {product-long-kafka} web console to view and inspect messages for a Kafka topic. You might use this functionality to verify that a client is producing messages to the expected topic partition or that messages have the expected content.
 
 When you select a topic in the web console, you can use the *Messages* tab to view a list of messages for that topic. You can filter the list of messages in the following ways:
 
@@ -156,13 +152,13 @@ NOTE: If you have many partitions, you can filter the values shown in the *Parti
 --
 * To filter messages by topic partition and offset, perform the following actions:
 ... In the *Partition* field, select a topic partition.
-... Click the arrow next to the default value of `Latest messages` and select `Offset` from the list.
+... Click the arrow next to `Latest messages` and select `Offset` from the list.
 ... In the *Specify offset* field, type an offset value.
 ... To apply your filter settings, click the search (magnifying glass) icon.
 
 * To filter messages by topic partition and date and time, perform the following actions:
 ... In the *Partition* field, select a topic partition.
-... Click the arrow next to the default value of `Latest messages` and select `Timestamp` from the list.
+... Click the arrow next to `Latest messages` and select `Timestamp` from the list.
 +
 Additional selection tools appear.
 ... Use the additional selection tools to set date and time values. Alternatively, type a date and time value in the format shown in the field.
@@ -170,7 +166,7 @@ Additional selection tools appear.
 
 * To filter messages by topic partition and epoch timestamp, perform the following actions:
 ... In the *Partition* field, select a topic partition.
-... Click the arrow next to the default value of `Latest messages` and select `Epoch timestamp` from the list.
+... Click the arrow next to `Latest messages` and select `Epoch timestamp` from the list.
 ... In the *Epoch timestamp* field, type or paste an epoch timestamp value.
 +
 NOTE: You can easily convert a human-readable date and time to an epoch value using a https://www.epochconverter.com/[timestamp conversion tool^].

--- a/docs/kafka/metrics-monitoring-kafka/README.adoc
+++ b/docs/kafka/metrics-monitoring-kafka/README.adoc
@@ -85,7 +85,7 @@ ifdef::context[:parent-context: {context}]
 
 // Purpose statement for the assembly
 [role="_abstract"]
-As a developer or administrator, you can view metrics in {product-kafka} to visualize the performance and data usage for Kafka instances and topics that you have access to. You can view metrics directly in the {product-kafka} web console, or use the metrics API endpoint provided by {product-kafka} to import the data into your own metrics monitoring tool, such as Prometheus.
+As a developer or administrator, you can view metrics in {product-long-kafka} to visualize the performance and data usage for Kafka instances and topics that you have access to. You can view metrics directly in the {product-kafka} web console, or use the metrics API endpoint provided by {product-kafka} to import the data into your own metrics monitoring tool, such as Prometheus.
 
 //Additional line break to resolve mod docs generation error, not sure why. Leaving for now. (Stetson, 20 May 2021)
 
@@ -93,7 +93,7 @@ As a developer or administrator, you can view metrics in {product-kafka} to visu
 == Supported metrics in {product-kafka}
 
 [role="_abstract"]
-{product-kafka} supports the following metrics for Kafka instances and topics. In the {product-kafka} web console, the *Dashboard* page of a Kafka instance displays a subset of these metrics. To learn more about the limits associated with both trial and production Kafka instance types, refer to https://access.redhat.com/articles/5979061[Red Hat OpenShift Streams for Apache Kafka Service Limits].
+{product-long-kafka} supports the following metrics for Kafka instances and topics. In the {product-kafka} web console, the *Dashboard* page of a Kafka instance displays a subset of these metrics. To learn more about the limits associated with both trial and production Kafka instance types, see https://access.redhat.com/articles/5979061[Red Hat OpenShift Streams for Apache Kafka Service Limits].
 
 
 Cluster metrics::
@@ -156,7 +156,7 @@ Topic metrics::
 == Viewing metrics for a Kafka instance in {product-kafka}
 
 [role="_abstract"]
-After you produce and consume messages in your services using methods such as link:https://kafka.apache.org/downloads[Kafka] scripts, link:https://github.com/edenhill/kcat[Kafkacat], or a link:https://quarkus.io/[Quarkus] application, you can return to the Kafka instance in the web console and use the *Dashboard* page to view metrics for the instance and topics. The metrics help you understand the performance and data usage for your Kafka instance and topics.
+After you produce and consume messages in your services using methods such as link:https://kafka.apache.org/downloads[Kafka^] scripts, link:https://github.com/edenhill/kcat[Kcat^], or a link:https://quarkus.io/[Quarkus^] application, you can return to the Kafka instance in the web console and use the *Dashboard* page to view metrics for the instance and topics. The metrics help you understand the performance and data usage for your Kafka instance and topics.
 
 .Prerequisites
 * You have access to a Kafka instance in {product-kafka} that contains topics. For more information about access management in {product-kafka}, see {base-url}{access-mgmt-url-kafka}[Managing account access in {product-long-kafka}^].
@@ -174,15 +174,15 @@ NOTE: In some cases, after you start producing and consuming messages, you might
 == Configuring metrics monitoring for a Kafka instance in Prometheus
 
 [role="_abstract"]
-As an alternative to viewing metrics for a Kafka instance in the {product-kafka} web console, you can export your metrics to https://prometheus.io/docs/introduction/overview/[Prometheus] and integrate the metrics with your own metrics monitoring platform. {product-kafka} provides a `kafkas/{id}/metrics/federate` API endpoint that you can configure as a scrape target for Prometheus to use to collect and store metrics. You can then access the metrics in the https://prometheus.io/docs/visualization/browser/[Prometheus expression browser] or in a data-graphing tool such as https://prometheus.io/docs/visualization/grafana/[Grafana].
+As an alternative to viewing metrics for a Kafka instance in the {product-long-kafka} web console, you can export your metrics to https://prometheus.io/docs/introduction/overview/[Prometheus^] and integrate the metrics with your own metrics monitoring platform. {product-kafka} provides a `kafkas/{id}/metrics/federate` API endpoint that you can configure as a scrape target for Prometheus to use to collect and store metrics. You can then access the metrics in the https://prometheus.io/docs/visualization/browser/[Prometheus expression browser^] or in a data-graphing tool such as https://prometheus.io/docs/visualization/grafana/[Grafana^].
 
-This procedure follows the https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file[Configuration File] method defined by Prometheus for integrating third-party metrics. If you use the Prometheus Operator in your monitoring environment, you can also follow the https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/additional-scrape-config.md#additional-scrape-configuration[Additional Scrape Configuration] method.
+This procedure follows the https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file[Configuration File^] method defined by Prometheus for integrating third-party metrics. If you use the Prometheus Operator in your monitoring environment, you can also follow the https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/additional-scrape-config.md#additional-scrape-configuration[Additional Scrape Configuration^] method.
 
 .Prerequisites
 * You have access to a Kafka instance that contains topics in {product-kafka}. For more information about access management in {product-kafka}, see {base-url}{access-mgmt-url-kafka}[Managing account access in {product-long-kafka}^].
 * You have the ID and the SASL/OAUTHBEARER token endpoint for the Kafka instance. To relocate the Kafka instance ID and the token endpoint, select your Kafka instance in the {product-kafka} web console, select the options menu (three vertical dots), and click *Connection*.
 * You have the generated credentials for your service account that has access to the Kafka instance. To reset the credentials, use the {service-accounts-url}[Service Accounts^] page in the *Application Services* section of the Red Hat Hybrid Cloud Console.
-* You've installed a Prometheus instance in your monitoring environment. For installation instructions, see https://prometheus.io/docs/prometheus/latest/getting_started/[Getting Started] in the Prometheus documentation.
+* You've installed a Prometheus instance in your monitoring environment. For installation instructions, see https://prometheus.io/docs/prometheus/latest/getting_started/[Getting Started^] in the Prometheus documentation.
 
 .Procedure
 . In your Prometheus configuration file, add the following information. Replace the variable values with your own Kafka instance and service account information.
@@ -206,10 +206,10 @@ The `<kafka_instance_id>` is the ID of the Kafka instance. The `<client_id>` and
 
 The new scrape target becomes available after the configuration has reloaded.
 --
-. View your collected metrics in the Prometheus expression browser at `http://__<host>__:__<port>__/graph`, or integrate your Prometheus data source with a data-graphing tool such as Grafana. For information about Prometheus metrics in Grafana, see https://prometheus.io/docs/visualization/grafana/[Grafana Support for Prometheus] in the Grafana documentation.
+. View your collected metrics in the Prometheus expression browser at `http://__<host>__:__<port>__/graph`, or integrate your Prometheus data source with a data-graphing tool such as Grafana. For information about Prometheus metrics in Grafana, see https://prometheus.io/docs/visualization/grafana/[Grafana Support for Prometheus^] in the Grafana documentation.
 +
 --
-If you use Grafana with your Prometheus instance, you can import the predefined https://grafana.com/grafana/dashboards/15835[{product-long-kafka} Grafana dashboard] to set up your metrics display. For import instructions, see https://grafana.com/docs/grafana/v7.5/dashboards/export-import/#importing-a-dashboard[Importing a dashboard] in the Grafana documentation.
+If you use Grafana with your Prometheus instance, you can import the predefined https://grafana.com/grafana/dashboards/15835[{product-long-kafka} Grafana dashboard^] to set up your metrics display. For import instructions, see https://grafana.com/docs/grafana/v7.5/dashboards/export-import/#importing-a-dashboard[Importing a dashboard^] in the Grafana documentation.
 --
 
 When you create a Kafka instance and add new topics, the metrics are initially empty. After you start producing and consuming messages in your services, you can return to your monitoring tool to view related metrics. For example, to use Kafka scripts to produce and consume messages, see {base-url}{kafka-bin-scripts-url-kafka}[Configuring and connecting Kafka scripts with {product-long-kafka}^].
@@ -218,7 +218,7 @@ NOTE: In some cases, after you start producing and consuming messages, you might
 
 [NOTE]
 ====
-If you use the Prometheus Operator in your monitoring environment, you can alternatively create a `kafka-federate.yaml` file as an additional scrape configuration in your Prometheus custom resource as shown in the following example commands. For more information about this method, see https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/additional-scrape-config.md#additional-scrape-configuration[Additional Scrape Configuration] in the Prometheus documentation.
+If you use the Prometheus Operator in your monitoring environment, you can alternatively create a `kafka-federate.yaml` file as an additional scrape configuration in your Prometheus custom resource as shown in the following example commands. For more information about this method, see https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/additional-scrape-config.md#additional-scrape-configuration[Additional Scrape Configuration^] in the Prometheus documentation.
 
 .Example `kafka-federate.yaml` file
 [source,yaml,subs="+quotes"]
@@ -263,7 +263,7 @@ spec:
 .Prerequisites
 * You have successfully configured metrics monitoring for a Kafka instance in Prometheus.
 * You use the Prometheus Operator in your monitoring environment.
-* You can define https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[alerting rules] in Prometheus and can deploy an https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/alerting.md/[Alertmanager cluster] in Prometheus Operator.
+* You can define https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[alerting rules^] in Prometheus and can deploy an https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/alerting.md/[Alertmanager cluster^] in Prometheus Operator.
 
 
 .Procedure
@@ -296,9 +296,9 @@ spec:
 * {base-url}{getting-started-url-kafka}[Getting started with {product-long-kafka}^]
 * {base-url}{getting-started-rhoas-cli-url-kafka}[Getting started with the `rhoas` CLI for {product-long-kafka}^]
 * {base-url-cli}{command-ref-url-cli}[CLI command reference (rhoas)^]
-* https://prometheus.io/docs/prometheus/latest/getting_started/[Getting Started] in the Prometheus documentation
-* https://prometheus.io/docs/visualization/grafana/[Grafana Support for Prometheus]
-* https://grafana.com/docs/grafana/latest/datasources/prometheus/[Prometheus Data Source] in the Grafana documentation
+* https://prometheus.io/docs/prometheus/latest/getting_started/[Getting Started^] in the Prometheus documentation
+* https://prometheus.io/docs/visualization/grafana/[Grafana Support for Prometheus^]
+* https://grafana.com/docs/grafana/latest/datasources/prometheus/[Prometheus Data Source^] in the Grafana documentation
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
Made the following updates in this preview of the [Messages](http://file.ams.redhat.com/aecollin/JK-9743/Messages/README.html) guide:

- Broke 2nd sentence into list for improved readability
- Amended one instance of 'console' to 'web console'
- Ensured full name of product used on first occurrence in each module
- Replaced 'drop-down menu- with 'list'
- Removed italics for guide links
- Removed references to 'offset' as default value and amended this default value to 'latest messages'
- Corrected typo

Made the following updates in this preview of the [Metrics](http://file.ams.redhat.com/aecollin/JK-9743/Metrics/README.html) guide:

- Amended 'refer to' to 'see'
- Added ^ symbol to external links
- Ensured full name of product used on first occurrence in each module
- Changed 'Kafkacat' to 'Kcat'