### PR TITLE
docs: JK-10139: updates to ensure that OpenShift Streams console quick starts don't refer to figures

### DIFF
--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -129,11 +129,16 @@ endif::[]
 .Procedure
 . In the {product-kafka} {service-url-kafka}[web console^], select *Kafka Instances* and click *Create Kafka instance*.
 +
+ifdef::qs[]
+The instance creation pane opens.
+endif::[]
+ifndef::qs[]
 The instance creation pane opens, as shown in the figure.
 +
 [.screencapture]
 .Kafka instance creation pane
 image::sak-configure-kafka-instance.png[Image of Create Kafka instance pane]
+endif::[]
 
 . Enter a unique name for the Kafka instance, such as `my-first-kafka-instance`.
 . In the *Cloud region* list, select the relevant option.
@@ -159,11 +164,15 @@ For more information about the support scope of Red Hat Technology Preview featu
 --
 The new Kafka instance is listed on the *Kafka Instances* page. Typically, you need to wait a few minutes for the instance creation process to finish.
 
+ifdef::qs[]
+When the instance has a status of *Ready*, you can start using the instance. You can click the options icon (three vertical dots) to view instance and connection details, change the instance owner, or delete the instance.
+endif::[]
+ifndef::qs[]
 When the instance has a status of *Ready*, you can start using the instance. As shown in the following figure, you can click the options icon (three vertical dots) to view instance and connection details, change the instance owner, or delete the instance.
-
 [.screencapture]
 .Kafka instance options menu
 image::sak-kafka-instance-options.png[Image of Kafka instance options menu]
+endif::[]
 
 NOTE: Although you can see Kafka instances created by other users in your organization, you might not be able to manage or connect to those instances. Only the instance owner or users with permissions to access the instance can edit or delete the instance, access the associated service account and topics, or connect to the instance.
 --
@@ -307,13 +316,18 @@ After you create a Kafka instance, you can create Kafka topics to start producin
 
 . In the {product-long-kafka} {service-url-kafka}[web console^], select *Kafka Instances* and then click the name of the Kafka instance that you want to add a topic to.
 . Select the *Topics* tab.
+ifdef::qs[]
+. Click *Create topic* and follow the guided steps to define the topic details.
+endif::[]
+ifndef::qs[]
 . Click *Create topic* and follow the guided steps to define the topic details, as shown in the figure.
 +
---
 [.screencapture]
 .Guided steps to define topic details
 image::sak-create-topic.png[Image of wizard to create a topic]
-
+endif::[]
++
+--
 You must specify the following topic properties:
 
 * *Topic name*: Enter a unique topic name, such as `my-first-kafka-topic`.
@@ -330,11 +344,12 @@ endif::[]
 NOTE: If the topic creation is unsuccessful and you see a `400 Bad Request` error message, try to create your topic again later. This situation might occur, for example, if your selected cloud provider has a temporary availability problem that affects your Kafka instance.
 --
 
+ifdef::qs[]
+. (Optional) To edit or delete the topic, click the options icon (three vertical dots) next to the topic name.
+endif::[]
+ifndef::qs[]
 . (Optional) To edit or delete the topic, click the options icon (three vertical dots) next to the topic name, as shown in the figure.
-+
-[.screencapture]
-.Edit or delete Kafka topic
-image::sak-edit-topic.png[Image of topic options to edit or delete]
+endif::[]
 
 .Verification
 ifdef::qs[]

--- a/docs/kafka/nodejs-kafka/README.adoc
+++ b/docs/kafka/nodejs-kafka/README.adoc
@@ -205,20 +205,18 @@ The Node.js application in this quick start uses a Kafka topic called `countries
 .Procedure
 . In the {product-kafka} {service-url-kafka}[web console^], select *Kafka Instances* and then click the name of the Kafka instance that you want to add a topic to.
 . Select the *Topics* tab.
-. Click *Create topic* and follow the guided steps to define the topic details, as shown in the figure.
+. Click *Create topic* and follow the guided steps to define the topic details.
 +
-[.screencapture]
-.Guided steps to define topic details
-image::sak-create-countries-topic.png[Image of wizard to create a topic]
-+
+--
 You must specify the following topic properties:
 
-* *Topic name*: Enter `countries` as the topic name.
-* *Partitions*: Set the number of partitions for this topic. This example sets the partitions value to `1`. Partitions are distinct lists of messages within a topic and enable parts of a topic to be distributed over multiple brokers in the cluster. A topic can contain one or more partitions, enabling producer and consumer loads to be scaled.
-* *Message retention*: Set the message retention time and size to the relevant value and increment. This example sets the retention time to `A week` and the retention size to `Unlimited`. Message retention time is the amount of time that messages are retained in a topic before they are deleted or compacted, depending on the cleanup policy. Retention size is the maximum total size of all log segments in a partition before they are deleted or compacted.
-* *Replicas*: Replicas are copies of partitions in a topic. For this release of {product-kafka}, the replica values are preconfigured. The number of partition replicas for the topic is set to `3` and the minimum number of follower replicas that must be in sync with a partition leader is set to `2`. For a trial Kafka instance, the number of replicas and the minimum in-sync replica factor are both set to `1`. Partition replicas are distributed over multiple brokers in the cluster to ensure topic availability if a broker fails. When a follower replica is in sync with a partition leader, the follower replica can become the new partition leader if needed.
-+
+* *Topic name*: For this quick start, enter `countries` as the topic name.
+* *Partitions*: Set the number of partitions for the topic. For this quick start, set the value to `1`.
+* *Message retention*: Set the message retention time and size. For this quick start, set the retention time to `A week` and the retention size to `Unlimited`.
+* *Replicas*: For this release of {product-kafka}, the replica values are preconfigured. The number of partition replicas for the topic is set to `3` and the minimum number of follower replicas that must be in sync with a partition leader is set to `2`. For a trial Kafka instance, the number of replicas and the minimum in-sync replica factor are both set to `1`.
+
 After you complete the setup, the new topic appears on the *Topics* page. You can now run the Node.js application to start producing and consuming messages.
+--
 
 .Verification
 ifdef::qs[]

--- a/docs/kafka/quarkus-kafka/README.adoc
+++ b/docs/kafka/quarkus-kafka/README.adoc
@@ -189,20 +189,18 @@ The Quarkus application in this quick start uses a Kafka topic called `prices` t
 .Procedure
 . In the {product-kafka} {service-url-kafka}[web console^], select *Kafka Instances* and then click the name of the Kafka instance that you want to add a topic to.
 . Select the *Topics* tab.
-. Click *Create topic* and follow the guided steps to define the topic details, as shown in the figure.
+. Click *Create topic* and follow the guided steps to define the topic details.
 +
-[.screencapture]
-.Guided steps to define topic details
-image::sak-create-topic.png[Image of wizard to create a topic]
-+
+--
 You must specify the following topic properties:
 
-* *Topic name*: Enter `prices` as the topic name.
-* *Partitions*: Set the number of partitions for this topic. This example sets the partitions value to `1`. Partitions are distinct lists of messages within a topic and enable parts of a topic to be distributed over multiple brokers in the cluster. A topic can contain one or more partitions, enabling producer and consumer loads to be scaled.
-* *Message retention*: Set the message retention time and size to the relevant value and increment. This example sets the retention time to `A week` and the retention size to `Unlimited`. Message retention time is the amount of time that messages are retained in a topic before they are deleted or compacted, depending on the cleanup policy. Retention size is the maximum total size of all log segments in a partition before they are deleted or compacted.
-* *Replicas*: Replicas are copies of partitions in a topic. For this release of {product-kafka}, the replica values are preconfigured. The number of partition replicas for the topic is set to `3` and the minimum number of follower replicas that must be in sync with a partition leader is set to `2`. For a trial Kafka instance, the number of replicas and the minimum in-sync replica factor are both set to `1`. Partition replicas are distributed over multiple brokers in the cluster to ensure topic availability if a broker fails. When a follower replica is in sync with a partition leader, the follower replica can become the new partition leader if needed.
-+
+* *Topic name*: For this quick start, enter `prices` as the topic name.
+* *Partitions*: Set the number of partitions for the topic. For this quick start, set the value to `1`.
+* *Message retention*: Set the message retention time and size. For this quick start, set the retention time to `A week` and the retention size to `Unlimited`.
+* *Replicas*: For this release of {product-kafka}, the replica values are preconfigured. The number of partition replicas for the topic is set to `3` and the minimum number of follower replicas that must be in sync with a partition leader is set to `2`. For a trial Kafka instance, the number of replicas and the minimum in-sync replica factor are both set to `1`.
+
 After you complete the setup, the new topic appears on the *Topics* page. You can now run the Quarkus application to start producing and consuming messages to and from this topic.
+--
 
 .Verification
 ifdef::qs[]

--- a/docs/rhoas/rhoas-produce-consume/README.adoc
+++ b/docs/rhoas/rhoas-produce-consume/README.adoc
@@ -128,14 +128,16 @@ In this task, you'll create a new topic in your Kafka instance. You'll use this 
 . Select the *Topics* tab.
 . Click *Create topic* and follow the guided steps to define the topic details.
 +
+--
 You must specify the following topic properties:
 
 * *Topic name*: For this quick start, enter `test-topic` as the topic name.
 * *Partitions*: Set the number of partitions for the topic. For this quick start, set the value to `2`.
 * *Message retention*: Set the message retention time and size. For this quick start, set the retention time to `A week` and the retention size to `Unlimited`.
-* *Replicas*: For this release of {product-kafka}, replica values are preconfigured. The number of partition replicas and the minimum number of follower replicas that must be in sync with a partition leader are both set to `1`.
-+
+* *Replicas*: For this release of {product-kafka}, replica values are preconfigured. The number of partition replicas for the topic is set to `3` and the minimum number of follower replicas that must be in sync with a partition leader is set to `2`. For a trial Kafka instance, the number of replicas and the minimum in-sync replica factor are both set to `1`.
+
 After you complete the setup, the new topic appears on the *Topics* page.
+--
 
 .Verification
 ifdef::qs[]


### PR DESCRIPTION
**Notes for reviewers**

- For the Getting Started quick start, introduced conditionlization for the console and Customer Portal versions of quick start.
- For the Quarkus and Node.js quick starts, trimmed the topic creation procedure to no longer use a figure. This made any further conditionalization unnecessary.
- Made a minor (unrelated to figures) update to docs/rhoas/rhoas-produce-consume/README.adoc to keep this in line with the Quarkus and Node.js quick starts
- Generated console versions of quick starts locally to verify that updates look as intended.
- Also verified Customer Portal versions locally.