### PR TITLE
docs: JK-6383: update guides to correctly describe configured ACL permissions

### DIFF
--- a/docs/kafka/access-mgmt-kafka/README.adoc
+++ b/docs/kafka/access-mgmt-kafka/README.adoc
@@ -200,7 +200,7 @@ a|
 * `Describe`
 |===
 
-By default, new Kafka instances contain the permissions shown in the following table. These permissions allow all accounts in the organization to view the instance permissions and to view topics in the instance, but not to produce or consume messages.
+By default, new Kafka instances have the permissions shown in the following table. These permissions allow all accounts in the organization to view the instance permissions and to view topics in the instance, but not to produce or consume messages.
 
 .Default ACL permissions for new Kafka instances
 [cols="25%,25%,25%,25%"]
@@ -274,9 +274,9 @@ The following permission options are available:
 ** *Produce to a topic*: Predefined permission entry for producing to one or more specified topics
 ** *Manage access*: Predefined permission entry for allowing other user accounts or service accounts to access and alter the permissions in the Kafka instance
 
-For example, when you create a new service account, select the *Consume from a topic* and *Produce to a topic* predefined options and set all resource identifiers and values to `Is *`. These permissions enable applications associated with the service account to create topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
+For example, when you create a new service account, select the *Consume from a topic* and *Produce to a topic* predefined options and set all resource identifiers and values to `Is *`.
 
-These permission settings result in the following ACL permissions for the new service account:
+These permission settings are shown in the following table:
 
 .Example ACL permissions for a new service account
 [cols="25%,25%,25%,25%"]
@@ -307,6 +307,8 @@ h|Operation
 |`Allow`
 |`Write`, `Create`, `Describe`
 |===
+
+The permissions shown in the table enable applications associated with the service account to create topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
 
 NOTE: Alternatively, you can click *Add permission* to individually create one `Topic` entry and one `Consumer group` entry, both with `Allow` access to `All` operations. This enables both consuming and producing for the topic in a single entry, and enables all permissions for the consumer group in a single entry. But you must configure these entries individually without using the predefined permission options.
 

--- a/docs/kafka/access-mgmt-kafka/README.adoc
+++ b/docs/kafka/access-mgmt-kafka/README.adoc
@@ -274,7 +274,7 @@ The following permission options are available:
 ** *Produce to a topic*: Predefined permission entry for producing to one or more specified topics
 ** *Manage access*: Predefined permission entry for allowing other user accounts or service accounts to access and alter the permissions in the Kafka instance
 
-For example, when you create a new service account, select the *Consume from a topic* and *Produce to a topic* predefined options and set all resource identifiers and values to `Is *`. These permissions enable applications associated with the service account to create and delete topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group and any producer.
+For example, when you create a new service account, select the *Consume from a topic* and *Produce to a topic* predefined options and set all resource identifiers and values to `Is *`. These permissions enable applications associated with the service account to create topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
 
 These permission settings result in the following ACL permissions for the new service account:
 
@@ -347,7 +347,7 @@ The following example Access Control Lists (ACLs) illustrate common scenarios fo
 Access for a new service account in a Kafka instance::
 +
 --
-You’ve created a new service account and you want to allow it to create and delete topics in the instance, to produce and consume messages in any topic in the instance, and to use any consumer group and any producer.
+You’ve created a new service account and you want to allow it to create and delete topics in the instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
 
 .Example ACL permissions
 [cols="25%,22%,23%,15%,15%"]
@@ -375,7 +375,7 @@ h|Operation
 Access for all accounts in a Kafka instance::
 +
 --
-You want this Kafka instance to be fully accessible to all accounts in the organization. You want any user to be able to read all topics, write to all topics, use any consumer group, and use any producer.
+You want this Kafka instance to be fully accessible to all accounts in the organization. You want any user to be able to read all topics, write to all topics, and use any consumer group.
 
 .Example ACL permissions
 [cols="25%,22%,23%,15%,15%"]

--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -248,12 +248,10 @@ After you create a service account to connect to a Kafka instance, you must also
 . Click the *Access* tab to view the current ACL for this instance.
 . To modify the ACL, click *Manage access*.
 . In the *Manage access* dialog box, use the *Account* list to select the service account that you previously created, and click *Next*.
-. Under *Assign Permissions*, use the list to select the *Consume from a topic* and the *Produce to a topic* permission options, and set all resource identifiers to `Is` and all identifier values to `*`.
+. Under *Assign Permissions*, use the list to select the *Consume from a topic* and the *Produce to a topic* permission options, and set all resource identifiers to `Is` and all identifier values to `*`. 
 +
 --
-These permissions enable applications associated with the service account to create topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
-
-These permission settings result in the following ACL permissions for the new service account:
+These settings result in the following ACL permissions for the new service account:
 
 .Example ACL permissions for a new service account
 [cols="25%,25%,25%,25%"]
@@ -284,6 +282,8 @@ h|Operation
 |`Allow`
 |`Write`, `Create`, `Describe`
 |===
+
+The permissions shown in the table enable applications associated with the service account to create topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
 
 NOTE: Alternatively, you can click *Add permission* to create individual permissions as needed. For example, you can create one `Topic` entry and one `Consumer group` entry, both with `Allow` access to `All` operations. This enables both consuming and producing for the specified topic in a single entry, and enables all permissions for the consumer group in another single entry. But you must configure these entries individually without using the predefined permission options.
 

--- a/docs/kafka/getting-started-kafka/README.adoc
+++ b/docs/kafka/getting-started-kafka/README.adoc
@@ -251,7 +251,7 @@ After you create a service account to connect to a Kafka instance, you must also
 . Under *Assign Permissions*, use the list to select the *Consume from a topic* and the *Produce to a topic* permission options, and set all resource identifiers to `Is` and all identifier values to `*`.
 +
 --
-These permissions enable applications associated with the service account to create and delete topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group and any producer.
+These permissions enable applications associated with the service account to create topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
 
 These permission settings result in the following ACL permissions for the new service account:
 

--- a/docs/kafka/service-binding-kafka/README.adoc
+++ b/docs/kafka/service-binding-kafka/README.adoc
@@ -370,7 +370,7 @@ The following ACL rules are to be created:
 ✔️ ACLs successfully created in the Kafka instance "my-kafka-instance"
 ----
 +
-The command you entered allows applications to create and delete topics in the instance, to produce and consume messages in any topic in the instance, and to use any consumer group and any producer.
+The command you entered allows applications to create topics in the instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
 
 . Use the OpenShift CLI to verify that the RHOAS Operator successfully created the connection.
 +

--- a/docs/registry/service-binding-registry/README.adoc
+++ b/docs/registry/service-binding-registry/README.adoc
@@ -413,7 +413,7 @@ The following ACL rules are to be created:
 ✔️ ACLs successfully created in the Kafka instance "my-kafka-instance"
 ----
 +
-In this example, the permissions you create allow applications to use the service account to create and delete topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group and any producer.
+In this example, the permissions you create allow applications to use the service account to create topics in the Kafka instance, to produce and consume messages in any topic in the instance, and to use any consumer group.
 
 .. If you connected to a {registry} instance, use Role-Based Access Control (RBAC) to enable the new service account to access the {registry} instance and the artifacts (such as schemas) that it contains.
 +

--- a/docs/rhoas/rhoas-service-contexts/README.adoc
+++ b/docs/rhoas/rhoas-service-contexts/README.adoc
@@ -333,7 +333,7 @@ As shown in the example, the file that you generate contains the endpoints for y
 $ rhoas kafka acl grant-access --producer --consumer --service-account _<client-id>_ --topic quotes --group all
 ----
 +
-The command you entered allows applications to use the service account to produce and consume messages in the `quotes` topic. Applications can use any consumer group and producer.
+The command you entered allows applications to use the service account to produce and consume messages in the `quotes` topic. Applications can use any consumer group.
 
 . Use Role-Based Access Control (RBAC) to enable the new service account to access the {registry} instance and the artifacts (such as schemas) that it contains.
 +
@@ -524,7 +524,7 @@ As indicated in the example, the generated secret has a default name of `service
 $ rhoas kafka acl grant-access --producer --consumer --service-account _<client-id>_ --topic prices --group all
 ----
 +
-The command you entered allows applications to use the service account to produce and consume messages in the `prices` topic. Applications can use any consumer group and producer.
+The command you entered allows applications to use the service account to produce and consume messages in the `prices` topic. Applications can use any consumer group.
 
 . Log in to the OpenShift CLI using a token by performing the following actions.
 .. Log in to the OpenShift web console as a user who has privileges to create a new project in the cluster.


### PR DESCRIPTION
**Notes for reviewers**

- As discussed in https://issues.redhat.com/browse/MGDSTRM-6383, removing incorrect statement (in a few guides) that says that the example ACL permissions shown allow applications to "use any producer". This is not the case.
- Also as discussed in the JIRA, there are a couple of instances where we incorrectly state that the example ACL permissions allow applications associated with the service account to delete topics. In fact, only the "Create" operation is set.
- HTML previews for the _Getting Started_ and _Access Management_ guides are [here](http://file.emea.redhat.com/~jbyrne/JK-6383/Getting%20started%20with%20OpenShift%20Streams%20for%20Apache%20Kafka.html) and [here](http://file.emea.redhat.com/~jbyrne/JK-6383/Managing%20account%20access%20in%20OpenShift%20Streams%20for%20Apache%20Kafka.html).