### PR TITLE
docs: JK-10345: Refined IaC guide and broke procedures into smaller ones

### DIFF
--- a/docs/rhoas/iac_tools_rhoas/README.adoc
+++ b/docs/rhoas/iac_tools_rhoas/README.adoc
@@ -211,7 +211,13 @@ $ ansible localhost -m rhoas.rhoas.create_kafka -a 'name=unique-kafka-name billi
 Ansible runs the `rhoas.rhoas.create_kafka` task in the terminal and creates the instance.
 
 . To open the example playbook used in later steps, use your IDE to navigate to the `rhoas` folder in the `.ansible` directory.
-. Open the `rhoas_test` example playbook. You can also open a web browser and navigate to https://github.com/redhat-developer/app-services-ansible/blob/main/rhoas_test.yml.
+. Open the `rhoas_test` example playbook. 
++
+[NOTE]
+====
+You can also open a web browser to view the https://github.com/redhat-developer/app-services-ansible/blob/main/rhoas_test.yml[`rhoas_test` playbook^].
+====
+
 . Inspect the contents of the example playbook. In particular, observe that the playbook has modules for certain tasks. You will use these modules to create a new playbook that performs the following tasks:
 +
 * Creating and deleting a Kafka instance
@@ -526,8 +532,8 @@ You can create, view, configure, and delete the following {product-kafka} resour
 * https://www.terraform.io/downloads[Terraform^] v1.3.4 or later is installed.
 
 .Procedure
-. In your web browser, open the {product-long-rhoas} (RHOAS) Terraform provider at https://registry.terraform.io/providers/redhat-developer/rhoas/latest.
-. In the upper-right corner of Terraform provider registry, click *Use Provider*.
+. In your web browser, navigate to the https://registry.terraform.io/providers/redhat-developer/rhoas/latest[{product-long-rhoas} (RHOAS) Terraform provider^].
+. In the upper-right corner of the RHOAS Terraform provider registry, click *Use Provider*.
 +
 A pane opens that shows the configuration you need to use the RHOAS Terraform provider.
 . In the pane that opened, copy the configuration shown. The following lines show an example of the configuration.

--- a/docs/rhoas/iac_tools_rhoas/README.adoc
+++ b/docs/rhoas/iac_tools_rhoas/README.adoc
@@ -210,8 +210,15 @@ $ ansible localhost -m rhoas.rhoas.create_kafka -a 'name=unique-kafka-name billi
 ----
 Ansible runs the `rhoas.rhoas.create_kafka` task in the terminal and creates the instance.
 
-. To open the example playbook used in later steps, use your IDE to navigate to the `rhoas` folder in the `.ansible` directory.
-. Open the `rhoas_test` example playbook. 
+[id="proc-creating-playbook-ansible_{context}"]
+=== Creating a playbook
+
+[role="_abstract"]
+
+This section shows you how to create and run an example playbook that allows you to manage your {product-long-kafka} resources.
+
+. To open the example playbook used in this section, use your IDE to navigate to the `rhoas` folder in the `.ansible` directory.
+. Open the `rhoas_test` example playbook.
 +
 [NOTE]
 ====
@@ -252,7 +259,7 @@ kafka_id: __<kafka_id>__
 ----
 
 [id="proc-creating-kafka-instance-ansible_{context}"]
-=== Creating a Kafka instance
+==== Creating a Kafka instance
 
 [role="_abstract"]
 To manage a Kafka instance using Ansible, you can use the `create_kafka` module and run it as part of a playbook or  as a single module.
@@ -294,10 +301,10 @@ All other information for the instance is provided by the Kafka APIs.
 When you run the `create_kafka_` module as part of the playbook at the end of these steps, Ansible saves the output of that command in a variable in the `register` field. In the preceding example, Ansible saves the created Kafka instance as `kafka_req_resp`.
 
 [id="proc-creating-service-account-ansible_{context}"]
-=== Creating a service account
+==== Creating a service account
 
 [role="_abstract"]
-To connect your applications or services to a Kafka instance in {product-kafka}, you must first create a service account with credentials. 
+To connect your applications or services to a Kafka instance in {product-kafka}, you must first create a service account with credentials.
 
 .Prerequisites
 
@@ -324,7 +331,7 @@ To connect your applications or services to a Kafka instance in {product-kafka},
 When you run the `create_service_account` module as part of the playbook at the end of these steps, Ansible populates the generated service account credentials in the `client_id` and `client_secret` fields in the terminal after it creates the service account.
 
 [id="proc-creating-acl-permissions-ansible_{context}"]
-=== Creating Access Control List permissions
+==== Creating Access Control List permissions
 
 [role="_abstract"]
 After you create a service account to connect to a Kafka instance, you must also set the appropriate level of access for that new account in an Access Control List (ACL) for the Kafka instance.
@@ -371,7 +378,7 @@ After you create a service account to connect to a Kafka instance, you must also
 `permission_type`:: Whether permission is given to the user or taken away.
 
 [id="proc-configuring-kafka-topic-ansible_{context}"]
-=== Configuring a Kafka topic
+==== Configuring a Kafka topic
 
 [role="_abstract"]
 After you create a Kafka instance, you can create Kafka topics to start producing and consuming messages in your applications and services.
@@ -442,10 +449,10 @@ After you create a Kafka instance, you can create Kafka topics to start producin
 . To directly specify a Kafka instance ID, enter a value in the `kafka_id` field. Otherwise, Ansible gets the Kafka ID from the `kafka_req_resp.id` variable.
 
 [id="proc-deleting-service-account-ansible_{context}"]
-=== Deleting a service account
+==== Deleting a service account
 
 [role="_abstract"]
-To delete a service account, use the `delete_service_account_by_id` module. 
+To delete a service account, use the `delete_service_account_by_id` module.
 
 .Prerequisites
 
@@ -468,10 +475,10 @@ To delete a service account, use the `delete_service_account_by_id` module.
 ----
 
 [id="proc-deleting-kafka-instance-ansible_{context}"]
-=== Deleting a Kafka instance
+==== Deleting a Kafka instance
 
 [role="_abstract"]
-To delete a Kafka instance, use the `delete_kafka_by_id` module. 
+To delete a Kafka instance, use the `delete_kafka_by_id` module.
 
 .Prerequisites
 
@@ -491,7 +498,7 @@ To delete a Kafka instance, use the `delete_kafka_by_id` module.
 . In the `openshift_offline_token` field, enter your OpenShift offline token.
 
 [id="proc-running-playbook-ansible_{context}"]
-=== Running the playbook
+==== Running the playbook
 
 [role="_abstract"]
 When you have finished creating the resources, run the playbook.
@@ -518,7 +525,7 @@ link:https://www.terraform.io/[HashiCorp Terraform^] is an Infrastructure as Cod
 === Installing the OpenShift Application Services Terraform provider
 
 [role="_abstract"]
-You can fully manage your Kafka environment through your Terraform system using the {product-long-rhoas} (RHOAS) link:https://registry.terraform.io/providers/redhat-developer/rhoas/latest[Terraform^] provider, which is available in the official link:https://www.terraform.io/[Terraform provider registry^]. 
+You can fully manage your Kafka environment through your Terraform system using the {product-long-rhoas} (RHOAS) link:https://registry.terraform.io/providers/redhat-developer/rhoas/latest[Terraform^] provider, which is available in the official link:https://www.terraform.io/[Terraform provider registry^].
 
 You can create, view, configure, and delete the following {product-kafka} resources:
 
@@ -581,7 +588,7 @@ When the Terraform provider has been initialized, you see a confirmation message
 Resources are the most important element in the Terraform language. Each resource block in a Terraform provider describes one or more infrastructure objects. For {product-long-kafka}, such infrastructure objects might include Kafka instances, service accounts, Access Control Lists (ACLs), and topics. The procedures that follow show what resources you can add to your Terraform configuration file to create a Kafka instance and its associated resources such as service accounts and topics.
 
 [id="proc-creating-kafka-instance-terraform_{context}"]
-=== Creating a Kafka instance
+==== Creating a Kafka instance
 
 [role="_abstract"]
 To manage a Kafka instance using Terraform, use the `rhoas_kafka` resource.
@@ -639,10 +646,10 @@ Running `terraform apply` for the first time also creates the Terraform state fi
 . To verify Terraform successfully created your Kafka instance, in your web browser, open the *Kafka Instances* page of the {product-kafka} {service-url-kafka}[web console^].
 
 [id="proc-creating-service-account-terraform_{context}"]
-=== Creating a service account
+==== Creating a service account
 
 [role="_abstract"]
-To connect your applications or services to a Kafka instance in {product-kafka}, you must first create a service account with credentials. 
+To connect your applications or services to a Kafka instance in {product-kafka}, you must first create a service account with credentials.
 
 .Prerequisites
 
@@ -684,7 +691,7 @@ In the terminal, Terraform displays a message that `rhoas_service_account.my-ser
 . To verify Terraform successfully created your service account, in your web browser, open the *Service Accounts* page of the {product-kafka} {service-url-kafka}[web console^].
 
 [id="proc-creating-acl-permissions-terraform_{context}"]
-=== Creating Access Control List permissions
+==== Creating Access Control List permissions
 
 [role="_abstract"]
 After you create a service account to connect to a Kafka instance, you must also set the appropriate level of access for that new account in an Access Control List (ACL) for the Kafka instance.
@@ -733,7 +740,7 @@ In the terminal, Terraform displays a message that `rhoas_acl.acl.` will be crea
 . When you're ready to set your permissions, type *yes*.
 
 [id="proc-creating-kafka-topic-terraform_{context}"]
-=== Creating a Kafka topic
+==== Creating a Kafka topic
 
 [role="_abstract"]
 After you create a Kafka instance, you can create Kafka topics to start producing and consuming messages in your applications and services.
@@ -770,10 +777,10 @@ In the terminal, Terraform displays a message that `rhoas_topic.my-topic` will b
 . To verify Terraform successfully created your topic, in your web browser, open the *Topics* page of the {product-kafka} {service-url-kafka}[web console^].
 
 [id="proc-deleting-resources_{context}"]
-=== Deleting resources
+==== Deleting resources
 
 [role="_abstract"]
-You can delete the resources you have created when you have finished using them. 
+You can delete the resources you have created when you have finished using them.
 
 .Prerequisites
 

--- a/docs/rhoas/iac_tools_rhoas/README.adoc
+++ b/docs/rhoas/iac_tools_rhoas/README.adoc
@@ -119,12 +119,7 @@ An Ansible role is a special kind of playbook that is fully self-contained and p
 === Installing the OpenShift Application Services Ansible collection
 
 [role="_abstract"]
-You can use the {product-long-rhoas} (RHOAS) https://galaxy.ansible.com/rhoas/rhoas[Ansible collection] to fully manage your Kafka environment with Ansible. You can create, view, configure, and delete the following {product-long-kafka} resources:
-
-* Kafka instances
-* Service accounts
-* Kafka topics
-* Access Control Lists (ACLs)
+The following procedure shows how to install the {product-long-rhoas} (RHOAS) https://galaxy.ansible.com/rhoas/rhoas[Ansible collection] allowing you to fully manage your Kafka environment with Ansible.
 
 .Prerequisites
 
@@ -181,7 +176,12 @@ $ ansible-doc rhoas.rhoas.create_kafka
 === Using the OpenShift Application Services Ansible collection
 
 [role="_abstract"]
-The procedures in this section show how to create and run an example playbook. The example playbook includes modules for creating a Kafka instance, topic, and service account, and assigning permissions to the service account. You also configure modules to delete the resources that you previously created.
+You can create, view, configure, and delete the following {product-long-kafka} resources with the {product-long-rhoas} (RHOAS) collection:
+
+* Kafka instances
+* Service accounts
+* Kafka topics
+* Access Control Lists (ACLs)
 
 .Prerequisites
 * You have a Red Hat account.
@@ -201,7 +201,7 @@ The offline token is a refresh token with no expiry and can be used by non-inter
 +
 NOTE: If you do not explicitly define the environment variables, the collection uses the URLs shown in the preceding step.
 
-. You can run a module in a terminal window to perform a single task. For example, the following command shows how to run a module that creates a Kafka instance.Replace _<OFFLINE_TOKEN>_ with your OpenShift offline token.
+. You can run a module in a terminal window to perform a single task. For example, the following command shows how to run a module that creates a Kafka instance. Replace _<OFFLINE_TOKEN>_ with your OpenShift offline token.
 +
 .Example create_kafka module
 [source,shell]
@@ -209,13 +209,14 @@ NOTE: If you do not explicitly define the environment variables, the collection 
 $ ansible localhost -m rhoas.rhoas.create_kafka -a 'name=unique-kafka-name billing_model=standard cloud_provider=aws plan="developer.x1" region="us-east-1" openshift_offline_token=<OFFLINE_TOKEN>'
 ----
 Ansible runs the `rhoas.rhoas.create_kafka` task in the terminal and creates the instance.
++
+You can also create a playbook of sequential tasks and use Ansible to automatically execute those tasks. The steps in the next section show you how to create and run an example playbook.
 
 [id="proc-creating-playbook-ansible_{context}"]
 === Creating a playbook
 
 [role="_abstract"]
-
-This section shows you how to create and run an example playbook that allows you to manage your {product-long-kafka} resources.
+The example playbook in this section includes modules for creating a Kafka instance, topic, and service account, and for assigning permissions to the service account. You also configure modules to delete the resources that you previously created.
 
 . To open the example playbook used in this section, use your IDE to navigate to the `rhoas` folder in the `.ansible` directory.
 . Open the `rhoas_test` example playbook.
@@ -338,7 +339,7 @@ After you create a service account to connect to a Kafka instance, you must also
 
 .Prerequisites
 
-* You have an offline token that authenticates the Terraform resources with the {product-long-rhoas} API.
+* You have an offline token that authenticates the Ansible modules with the {product-long-rhoas} API.
 * You have created a Kafka instance.
 * You understand how Access Control Lists (ACLs) enable you to manage how user accounts and service accounts can access the Kafka resources that you create. See {base-url}{access-mgmt-url-kafka}[Managing account access in {product-long-kafka}^].
 
@@ -432,7 +433,14 @@ After you create a Kafka instance, you can create Kafka topics to start producin
 ----
 . To directly specify a Kafka instance ID, enter a value in the `kafka_id` field. Otherwise, Ansible gets the Kafka ID from the `kafka_req_resp.id` variable.
 . (Optional) You can modify the values in the `retention_period_ms` and `retention_size_bytes` fields instead of accepting the default values.
-. To delete the topic, copy the `delete_kafka_topic` module shown in the following example and paste it into the `rhoas_kafka.yml` file.
+
+[id="proc-deleting-topic-ansible_{context}"]
+==== Deleting a Kafka topic
+
+[role="_abstract"]
+To delete a topic, use the `delete_kafka_topic` module.
+
+. Copy the `delete_kafka_topic` module shown in the following example and paste it into the `rhoas_kafka.yml` file.
 +
 .Example `delete_kafka_topic` module
 [source,yaml]
@@ -505,8 +513,8 @@ When you have finished creating the resources, run the playbook.
 
 .Procedure
 
-* Save any changes you have made to the the example `rhoas_test` playbook.
-* Open a terminal and enter the following command to run the playbook:
+. Save any changes you have made to the the example `rhoas_test` playbook.
+. Open a terminal and enter the following command to run the playbook:
 +
 [source, shell]
 ----
@@ -603,7 +611,7 @@ To manage a Kafka instance using Terraform, use the `rhoas_kafka` resource.
 The offline token is a refresh token with no expiry and can be used by non-interactive processes to provide an access token for OpenShift Application Services to authenticate the user. The token is an OpenShift offline token and you can find it at https://cloud.redhat.com/openshift/token. Because the offline token is a sensitive value that varies between environments it is best specified as an `OFFLINE_TOKEN` environment variable when running `terraform apply` in a terminal. To set this environment variable, enter the following command in a terminal window, replacing _<offline_token>_ with the value of the offline token:
 [source, subs="+quotes"]
 ----
-export OFFLINE_TOKEN=<offline_token>
+export OFFLINE_TOKEN=_<offline_token>_
 ----
 ====
 
@@ -705,15 +713,6 @@ After you create a service account to connect to a Kafka instance, you must also
 .Procedure
 
 . To create Access Control List (ACL) permissions with some default values, copy and paste the `rhoas_acl` resource shown in the following example into the `main.tf` file. This example uses the `"acl"` identifier.
-. Consider whether you need to specify your own value for any of the fields in the following list. These fields must all have values in an ACL binding resource.
-
-`resource_type`:: The type of resource you grant access to. This example uses `“TOPIC”`.
-`resource_name`:: The name of the Kafka resource  you grant access to. This example uses the name that is passed when creating the topic.
-`pattern_type`:: The type of pattern of the ACL. This example uses the `LITERAL` pattern type meaning that Kafka will try to match the match the full resource name (the topic) with the resource specified in the ACL.
-`principal`:: The user or service account that this binding applies to. This example uses the service account client ID.
-`operation_type`:: The type of operation (an action performed on a resource) that is allowed for the given user on this resource.
-`permission_type`:: Whether permission is given or taken away.
-
 +
 .Example `ACL binding` resource
 [source]
@@ -729,6 +728,14 @@ resource "rhoas_acl" "acl" {
 }
 
 ----
+. Consider whether you need to specify your own value for any of the fields in the following list. These fields must all have values in an ACL binding resource.
+
+`resource_type`:: The type of resource you grant access to. This example uses `“TOPIC”`.
+`resource_name`:: The name of the Kafka resource  you grant access to. This example uses the name that is passed when creating the topic.
+`pattern_type`:: The type of pattern of the ACL. This example uses the `LITERAL` pattern type meaning that Kafka will try to match the match the full resource name (the topic) with the resource specified in the ACL.
+`principal`:: The user or service account that this binding applies to. This example uses the service account client ID.
+`operation_type`:: The type of operation (an action performed on a resource) that is allowed for the given user on this resource.
+`permission_type`:: Whether permission is given or taken away.
 . Save your changes.
 . Apply the changes you made to your Terraform provider configuration.
 +
@@ -752,7 +759,7 @@ After you create a Kafka instance, you can create Kafka topics to start producin
 
 .Procedure
 
-. To create a Kafka topic with default values, copy and paste the `rhoas_topic` resource shown in the following example into the `main.tf` file. This example uses the `topic` identifier and creates the `my-topic` Kafka topic. As you have already created the Kafka instance, Terraform can check dependencies for this new topic resource and knows the Kafka ID when you run this example resource.
+. To create a Kafka topic with default values, copy and paste the `rhoas_topic` resource shown in the following example into the `main.tf` file. This example uses the `topic` identifier and creates the `my-topic` Kafka topic. Because you have already created the Kafka instance, Terraform can check dependencies for this new topic resource and knows the Kafka ID when you run this example resource.
 +
 .Example `rhoas_topic` resource with default values
 [source]

--- a/docs/rhoas/iac_tools_rhoas/README.adoc
+++ b/docs/rhoas/iac_tools_rhoas/README.adoc
@@ -181,7 +181,7 @@ $ ansible-doc rhoas.rhoas.create_kafka
 === Using the OpenShift Application Services Ansible collection
 
 [role="_abstract"]
-The procedure in this section shows how to create and run an example playbook. The example playbook includes modules for creating a Kafka instance, topic, and service account, and assigning permissions to the service account. You also configure modules to delete the resources that you previously created.
+The procedures in this section show how to create and run an example playbook. The example playbook includes modules for creating a Kafka instance, topic, and service account, and assigning permissions to the service account. You also configure modules to delete the resources that you previously created.
 
 .Prerequisites
 * You have a Red Hat account.
@@ -201,17 +201,15 @@ The offline token is a refresh token with no expiry and can be used by non-inter
 +
 NOTE: If you do not explicitly define the environment variables, the collection uses the URLs shown in the preceding step.
 
-. Open a terminal window.
-. Run a module in the terminal to perform a single task. For example, the following command shows how to run a module that creates a Kafka instance. Replace _<OFFLINE_TOKEN>_ with your OpenShift offline token.
+. You can run a module in a terminal window to perform a single task. For example, the following command shows how to run a module that creates a Kafka instance.Replace _<OFFLINE_TOKEN>_ with your OpenShift offline token.
 +
 .Example create_kafka module
 [source,shell]
 ----
 $ ansible localhost -m rhoas.rhoas.create_kafka -a 'name=unique-kafka-name billing_model=standard cloud_provider=aws plan="developer.x1" region="us-east-1" openshift_offline_token=<OFFLINE_TOKEN>'
 ----
-
-+
 Ansible runs the `rhoas.rhoas.create_kafka` task in the terminal and creates the instance.
+
 . To open the example playbook used in later steps, use your IDE to navigate to the `rhoas` folder in the `.ansible` directory.
 . Open the `rhoas_test` example playbook. You can also open a web browser and navigate to https://github.com/redhat-developer/app-services-ansible/blob/main/rhoas_test.yml.
 . Inspect the contents of the example playbook. In particular, observe that the playbook has modules for certain tasks. You will use these modules to create a new playbook that performs the following tasks:
@@ -247,9 +245,22 @@ kafka_id: __<kafka_id>__
   tasks:
 ----
 
-. To add a module that creates a new Kafka instance, copy the `create_kafka` module shown in the following example and paste it into the `tasks:` section of your `rhoas_kafka.yml` file.
+[id="proc-creating-kafka-instance-ansible_{context}"]
+=== Creating a Kafka instance
 
+[role="_abstract"]
+To manage a Kafka instance using Ansible, you can use the `create_kafka` module and run it as part of a playbook or  as a single module.
+
+.Prerequisites
+
+* You have a Red Hat account.
+* You have an offline token that authenticates the Ansible modules with the {product-long-rhoas} API.
+
+.Procedure
+
+. To add a module that creates a new Kafka instance to a playbook, copy the `create_kafka` module shown in the following example and paste it into the `tasks:` section of your `rhoas_kafka.yml` file.
 +
+
 .Example `create_kafka` module
 [source,yaml]
 ----
@@ -266,15 +277,30 @@ kafka_id: __<kafka_id>__
     register:
       kafka_req_resp
 ----
++
+
 . In the `name` field, enter a name for the Kafka instance.
 . In the `billing_cloud_account_id`, enter the billing cloud account ID.
 . In the `openshift_offline_token` field, enter your OpenShift offline token.
 +
 All other information for the instance is provided by the Kafka APIs.
 +
-When you run the `create_kafka_` module as part of the playbook at the end of this procedure, Ansible saves the output of that command in a variable in the `register` field. In the preceding example, Ansible saves the created Kafka instance as `kafka_req_resp`.
+When you run the `create_kafka_` module as part of the playbook at the end of these steps, Ansible saves the output of that command in a variable in the `register` field. In the preceding example, Ansible saves the created Kafka instance as `kafka_req_resp`.
 
-. To connect your applications or services to a Kafka instance in {product-kafka}, you must first create a service account with credentials. To add a module that creates a service account, copy the `create_service_account` module shown in the following example and paste it into the `rhoas_kafka.yml` file.
+[id="proc-creating-service-account-ansible_{context}"]
+=== Creating a service account
+
+[role="_abstract"]
+To connect your applications or services to a Kafka instance in {product-kafka}, you must first create a service account with credentials. 
+
+.Prerequisites
+
+* You have an offline token that authenticates the Ansible modules with the {product-long-rhoas} API.
+* You have created a Kafka instance.
+
+.Procedure
+
+. To add a module that creates a service account, copy the `create_service_account` module shown in the following example and paste it into the `rhoas_kafka.yml` file.
 +
 .Example `create_service_account` module
 [source,yaml]
@@ -289,7 +315,22 @@ When you run the `create_kafka_` module as part of the playbook at the end of th
 ----
 . Enter values for the `name`, `short description`, and `openshift_offline_token` fields.
 +
-When you run the `create_service_account` module as part of the playbook at the end of this procedure, Ansible populates the generated service account credentials in the `client_id` and `client_secret` fields in the terminal after it creates the service account.
+When you run the `create_service_account` module as part of the playbook at the end of these steps, Ansible populates the generated service account credentials in the `client_id` and `client_secret` fields in the terminal after it creates the service account.
+
+[id="proc-creating-acl-permissions-ansible_{context}"]
+=== Creating Access Control List permissions
+
+[role="_abstract"]
+After you create a service account to connect to a Kafka instance, you must also set the appropriate level of access for that new account in an Access Control List (ACL) for the Kafka instance.
+
+.Prerequisites
+
+* You have an offline token that authenticates the Terraform resources with the {product-long-rhoas} API.
+* You have created a Kafka instance.
+* You understand how Access Control Lists (ACLs) enable you to manage how user accounts and service accounts can access the Kafka resources that you create. See {base-url}{access-mgmt-url-kafka}[Managing account access in {product-long-kafka}^].
+
+.Procedure
+
 . To create Access Control List (ACL) permissions for the service account and bind that ACL to the Kafka instance, copy the `create_kafka_acl_binding` module shown in the following example and paste it in your `rhoas_kafka.yml` file.
 +
 .Example `create_kafka_acl_binding` module
@@ -322,6 +363,19 @@ When you run the `create_service_account` module as part of the playbook at the 
 `pattern_type`:: The type of pattern of the ACL. This example uses the `PREFIXED` pattern type meaning that Kafka will try to match the prefix of the resource name with the resource specified in the ACL.
 `operation_type`:: The type of operation (an action performed on a resource) that is allowed for the given user on this module.
 `permission_type`:: Whether permission is given to the user or taken away.
+
+[id="proc-configuring-kafka-topic-ansible_{context}"]
+=== Configuring a Kafka topic
+
+[role="_abstract"]
+After you create a Kafka instance, you can create Kafka topics to start producing and consuming messages in your applications and services.
+
+.Prerequisites
+
+* You have an offline token that authenticates the Ansible modules with the Kafka Management API.
+* You have created a Kafka instance.
+
+.Procedure
 
 . To create a Kafka topic, copy the contents of the `create_kafka_topic` module shown in the following example and paste it into the `rhoas_kafka.yml` file.
 +
@@ -380,10 +434,23 @@ When you run the `create_service_account` module as part of the playbook at the 
 ----
 . In the `openshift_offline_token` field, enter your OpenShift offline token.
 . To directly specify a Kafka instance ID, enter a value in the `kafka_id` field. Otherwise, Ansible gets the Kafka ID from the `kafka_req_resp.id` variable.
+
+[id="proc-deleting-service-account-ansible_{context}"]
+=== Deleting a service account
+
+[role="_abstract"]
+To delete a service account, use the `delete_service_account_by_id` module. 
+
+.Prerequisites
+
+* You have created a service account.
+
+.Procedure
+
 . To delete the service account, copy the `delete_service_account_by_id` module shown in the following example and paste it into the `rhoas_kafka.yml` file.
 . To directly specify a service account ID, enter a value in the `service_account_id` field. Otherwise, Ansible gets the service account ID from the `srvce_acc_resp_obj` variable.
 +
-.Example `delete_service_account_by_id` module
+.Example `deleting_service_account_by_id` module
 [source,yaml]
 ----
 - name: Delete Service Account
@@ -394,6 +461,17 @@ When you run the `create_service_account` module as part of the playbook at the 
   # openshift_offline_token: "OFFLINE_TOKEN"
 ----
 
+[id="proc-deleting-kafka-instance-ansible_{context}"]
+=== Deleting a Kafka instance
+
+[role="_abstract"]
+To delete a Kafka instance, use the `delete_kafka_by_id` module. 
+
+.Prerequisites
+
+* You have created a Kafka instance.
+
+.Procedure
 . To deprovision and delete the {product-kafka} instance, copy the `delete_kafka_by_id` module shown in the following example and paste it into the `rhoas_kafka.yml` file.
 +
 .Example `delete_kafka_by_id` module
@@ -405,8 +483,17 @@ When you run the `create_service_account` module as part of the playbook at the 
      openshift_offline_token: "offline_token"
 ----
 . In the `openshift_offline_token` field, enter your OpenShift offline token.
-. Save your changes.
-. Open a terminal and enter the following command to run the example `rhoas_test` playbook:
+
+[id="proc-running-playbook-ansible_{context}"]
+=== Running the playbook
+
+[role="_abstract"]
+When you have finished creating the resources, run the playbook.
+
+.Procedure
+
+* Save any changes you have made to the the example `rhoas_test` playbook.
+* Open a terminal and enter the following command to run the playbook:
 +
 [source, shell]
 ----
@@ -418,20 +505,21 @@ The playbook runs through the tasks sequentially, generating output in the termi
 [id="con-terraform_{context}"]
 == Terraform
 
+[role="_abstract"]
 link:https://www.terraform.io/[HashiCorp Terraform^] is an Infrastructure as Code (Iac) tool that enables you to build and change infrastructure safely and efficiently through human-readable configuration files that you can create versions of, reuse, and share. You can then use a consistent workflow to provision and manage all of your infrastructure throughout its lifecycle.
 
-The {product-long-rhoas} (RHOAS) link:https://registry.terraform.io/providers/redhat-developer/rhoas/latest[Terraform^] provider is available in the official link:https://www.terraform.io/[Terraform provider registry^] and includes resources to interact with {product-long-rhoas}.
+[id="proc-install-rhoas-terraform-provider_{context}"]
+=== Installing the OpenShift Application Services Terraform provider
 
-You can fully manage your Kafka environment through your Terraform system using the RHOAS Terraform provider. You can create, view, configure, and delete the following {product-kafka} resources:
+[role="_abstract"]
+You can fully manage your Kafka environment through your Terraform system using the {product-long-rhoas} (RHOAS) link:https://registry.terraform.io/providers/redhat-developer/rhoas/latest[Terraform^] provider, which is available in the official link:https://www.terraform.io/[Terraform provider registry^]. 
+
+You can create, view, configure, and delete the following {product-kafka} resources:
 
 * Kafka instances
 * Service accounts
 * Kafka topics
 * Access Control Lists (ACLs)
-
-
-[id="proc-install-rhoas-terraform-provider_{context}"]
-=== Installing the OpenShift Application Services Terraform provider
 
 .Prerequisites
 * You have a Red Hat account.
@@ -480,10 +568,17 @@ $ terraform init
 ----
 When the Terraform provider has been initialized, you see a confirmation message.
 
-[id="proc-using-terraform_{context}"]
+[id="con-using-terraform_{context}"]
 === Using the OpenShift Application Services Terraform provider
 
-Resources are the most important element in the Terraform language. Each resource block in a Terraform provider describes one or more infrastructure objects. For {product-long-kafka}, such infrastructure objects might include Kafka instances, service accounts, Access Control Lists (ACLs), and topics. The procedure that follows shows what resources you can add to your Terraform configuration file to create a Kafka instance and its associated resources such as service accounts and topics.
+[role="_abstract"]
+Resources are the most important element in the Terraform language. Each resource block in a Terraform provider describes one or more infrastructure objects. For {product-long-kafka}, such infrastructure objects might include Kafka instances, service accounts, Access Control Lists (ACLs), and topics. The procedures that follow show what resources you can add to your Terraform configuration file to create a Kafka instance and its associated resources such as service accounts and topics.
+
+[id="proc-creating-kafka-instance-terraform_{context}"]
+=== Creating a Kafka instance
+
+[role="_abstract"]
+To manage a Kafka instance using Terraform, use the `rhoas_kafka` resource.
 
 .Prerequisites
 
@@ -536,7 +631,21 @@ In the terminal, Terraform displays a message that `rhoas_kafka.my-instance` wil
 Running `terraform apply` for the first time also creates the Terraform state file. Terraform logs information about the resources it has created in this state file. This allows Terraform to know which resources are under its control and when to update and delete them. The Terraform state file is named `terraform.tfstate` by default and is kept in the same directory where Terraform is run. Sensitive information such as the offline token, client ID, and client secret can be found in the `terraform.tfstate` file. Running `terraform apply` again updates this file.
 
 . To verify Terraform successfully created your Kafka instance, in your web browser, open the *Kafka Instances* page of the {product-kafka} {service-url-kafka}[web console^].
-. To connect your applications or services to a Kafka instance in {product-kafka}, you must first create a service account with credentials. To create a service account, copy and paste the  `rhoas_service_account` resource shown in the following example into the `main.tf` file. This example uses the `"my-service-account"` identifier and creates a service account called `my-service-account`.
+
+[id="proc-creating-service-account-terraform_{context}"]
+=== Creating a service account
+
+[role="_abstract"]
+To connect your applications or services to a Kafka instance in {product-kafka}, you must first create a service account with credentials. 
+
+.Prerequisites
+
+* You have an offline token that authenticates the Terraform resources with the {product-long-rhoas} API.
+* You have created a Kafka instance.
+
+.Procedure
+
+. To create a service account, copy and paste the  `rhoas_service_account` resource shown in the following example into the `main.tf` file. This example uses the `"my-service-account"` identifier and creates a service account called `my-service-account`.
 +
 
 .Example `rhoas_service_account` resource
@@ -567,29 +676,21 @@ $ terraform apply
 In the terminal, Terraform displays a message that `rhoas_service_account.my-service-account` will be created.
 . When you're ready to create your service account, type *yes*. The generated client ID appears in the terminal as an output. The client secret does not appear because it is marked as a sensitive value.
 . To verify Terraform successfully created your service account, in your web browser, open the *Service Accounts* page of the {product-kafka} {service-url-kafka}[web console^].
-. To create a Kafka topic with default values, copy and paste the `rhoas_topic` resource shown in the following example into the `main.tf` file. This example uses the `topic` identifier and creates the `my-topic` Kafka topic. As you have already created the Kafka instance, Terraform can check dependencies for this new topic resource and knows the Kafka ID when you run this example resource.
-+
-.Example `rhoas_topic` resource with default values
-[source]
-----
-resource "rhoas_topic" "topic" {
-		name = "my-topic"
-		partitions = 1
-		kafka_id = rhoas_kafka.instance.id
-	}
 
-----
-+
-. Save your changes.
-. Apply the changes you made to your Terraform provider configuration.
-+
-[source, shell]
-----
-$ terraform apply
-----
-In the terminal, Terraform displays a message that `rhoas_topic.my-topic` will be created.
-. When you're ready to create your topic, type *yes*.
-. To verify Terraform successfully created your topic, in your web browser, open the *Topics* page of the {product-kafka} {service-url-kafka}[web console^].
+[id="proc-creating-acl-permissions-terraform_{context}"]
+=== Creating Access Control List permissions
+
+[role="_abstract"]
+After you create a service account to connect to a Kafka instance, you must also set the appropriate level of access for that new account in an Access Control List (ACL) for the Kafka instance.
+
+.Prerequisites
+
+* You have an offline token that authenticates the Terraform resources with the {product-long-rhoas} API.
+* You have created a Kafka instance.
+* You understand how Access Control Lists (ACLs) enable you to manage how user accounts and service accounts can access the Kafka resources that you create. See {base-url}{access-mgmt-url-kafka}[Managing account access in {product-long-kafka}^].
+
+.Procedure
+
 . To create Access Control List (ACL) permissions with some default values, copy and paste the `rhoas_acl` resource shown in the following example into the `main.tf` file. This example uses the `"acl"` identifier.
 . Consider whether you need to specify your own value for any of the fields in the following list. These fields must all have values in an ACL binding resource.
 
@@ -624,7 +725,57 @@ $ terraform apply
 ----
 In the terminal, Terraform displays a message that `rhoas_acl.acl.` will be created.
 . When you're ready to set your permissions, type *yes*.
-. (Optional) To delete the created resources, enter the following command:
+
+[id="proc-creating-kafka-topic-terraform_{context}"]
+=== Creating a Kafka topic
+
+[role="_abstract"]
+After you create a Kafka instance, you can create Kafka topics to start producing and consuming messages in your applications and services.
+
+.Prerequisites
+
+* You have an offline token that authenticates the Terraform resources with the {product-long-rhoas} API.
+* You have created a Kafka instance.
+
+.Procedure
+
+. To create a Kafka topic with default values, copy and paste the `rhoas_topic` resource shown in the following example into the `main.tf` file. This example uses the `topic` identifier and creates the `my-topic` Kafka topic. As you have already created the Kafka instance, Terraform can check dependencies for this new topic resource and knows the Kafka ID when you run this example resource.
++
+.Example `rhoas_topic` resource with default values
+[source]
+----
+resource "rhoas_topic" "topic" {
+		name = "my-topic"
+		partitions = 1
+		kafka_id = rhoas_kafka.instance.id
+	}
+
+----
++
+. Save your changes.
+. Apply the changes you made to your Terraform provider configuration.
++
+[source, shell]
+----
+$ terraform apply
+----
+In the terminal, Terraform displays a message that `rhoas_topic.my-topic` will be created.
+. When you're ready to create your topic, type *yes*.
+. To verify Terraform successfully created your topic, in your web browser, open the *Topics* page of the {product-kafka} {service-url-kafka}[web console^].
+
+[id="proc-deleting-resources_{context}"]
+=== Deleting resources
+
+[role="_abstract"]
+You can delete the resources you have created when you have finished using them. 
+
+.Prerequisites
+
+* You have created Terraform resources.
+
+.Procedure
+
+* To delete the created resources, enter the following command:
 +
 [source,shell]
 ----

--- a/docs/rhoas/iac_tools_rhoas/README.adoc
+++ b/docs/rhoas/iac_tools_rhoas/README.adoc
@@ -119,7 +119,7 @@ An Ansible role is a special kind of playbook that is fully self-contained and p
 === Installing the OpenShift Application Services Ansible collection
 
 [role="_abstract"]
-The following procedure shows how to install the {product-long-rhoas} (RHOAS) https://galaxy.ansible.com/rhoas/rhoas[Ansible collection] allowing you to fully manage your Kafka environment with Ansible.
+The following procedure shows how to install the {product-long-rhoas} (RHOAS) https://galaxy.ansible.com/rhoas/rhoas[Ansible collection^] allowing you to fully manage your Kafka environment with Ansible.
 
 .Prerequisites
 


### PR DESCRIPTION
- Refined guide by breaking large procedures into several smaller ones.
- Corrected a few typos.
- Replaced raw URLs with linked text to aid screenreaders
- Added a note to a step to improve readability 
- Note to reviewers: preview available [here](http://file.ams.redhat.com/aecollin/JK-10345/README.html).