### PR TITLE
Add "scope" to sasl.jaas.config

### DIFF
--- a/docs/kafka/kafka-bin-scripts-kafka/README.adoc
+++ b/docs/kafka/kafka-bin-scripts-kafka/README.adoc
@@ -152,8 +152,9 @@ security.protocol=SASL_SSL
 sasl.oauthbearer.token.endpoint.url= {sso-token-url}
 
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
-clientId="<client-id>" \
-clientSecret="<client-secret>" ;
+  scope="openid" \
+  clientId="<client-id>" \
+  clientSecret="<client-secret>" ;
 
 sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
 ----


### PR DESCRIPTION
When using the OAuthBearerLoginCallbackHandler (as specified as the value for `sasl.login.callback.handler.class` in this example config), and when using `sso.redhat.com` (or potentially other Keycloak and maybe some other OAuth servers), which we do, then without specifying a scope will currently lead to a response with an empty scope, which is invalid and leads to failure.

The `sso.redhat.com` folks have suggested `openid` as the scope value, and I've verified that it works.

This seems to be the only place where `org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler` is used in this repo, I'm not sure if it's used in any other docs or quickstarts?

Where `io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler` is used in some other cases here instead, then scope does not need to be set.

Whether we should either change all cases to `org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler`, or otherwise specify a scope in both cases, is not a question I have an answer to.