### PR TITLE
Use commit SHA instead of branch name for third-party actions

### DIFF
--- a/.github/workflows/modular-docs-check.yml
+++ b/.github/workflows/modular-docs-check.yml
@@ -33,7 +33,8 @@ jobs:
         java-version: 15
         distribution: 'adopt' # See 'Supported distributions' for available options
     - name: Use Ruby 2.6
-      uses: ruby/setup-ruby@v1
+      # v1
+      uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2
       with:
         ruby-version: '2.6'
 


### PR DESCRIPTION
Hi!
Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.