### PR TITLE
Use commit SHA instead of branch name for third-party actions

### DIFF
--- a/.github/workflows/modular-docs-publish.yml
+++ b/.github/workflows/modular-docs-publish.yml
@@ -40,7 +40,8 @@ jobs:
           java-version: 15
           distribution: 'adopt' # See 'Supported distributions' for available options
       - name: Use Ruby 2.6
-        uses: ruby/setup-ruby@v1
+        # v1
+        uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2
         with:
           ruby-version: '2.6'
 
@@ -54,7 +55,8 @@ jobs:
         env:
           DOCS_PRODUCT_NAME: ${{matrix.product}}
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        # 4.1.5
+        uses: JamesIves/github-pages-deploy-action@0f24da7de3e7e135102609a4c9633b025be8411b
         env:
           DEPLOY_BRANCH: ${{matrix.branch}}
         with:


### PR DESCRIPTION
Hi!
Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.