### PR TITLE
docs: remove stale apicurio rest api url from sr access guide

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -9,7 +9,7 @@
 
 The guides toolchain is heavily dependent on AsciiDoc and Node.
 
-. Install your favourite tool for editing AsciiDoc (for example, Atom or VS Code).
+. Install your favourite tool for editing AsciiDoc (for example, VS Code or IntelliJ).
 . Install the latest Active long-term support (LTS) version of link:https://nodejs.org/en/about/releases/[Node] (`node`) .
 . Install link:https://github.com/nvm-sh/nvm[Node Version Manager] (`nvm`).
 . After you install `node` and `nvm`, run the following commands from your local  `app-services-guides` repository's top-level directory (for example, `Users/myname/mylocalGitRepos/app-services-guides/`):

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -9,7 +9,7 @@
 
 The guides toolchain is heavily dependent on AsciiDoc and Node.
 
-. Install your favourite tool for editing AsciiDoc (for example, Atom).
+. Install your favourite tool for editing AsciiDoc (for example, Atom or VS Code).
 . Install the latest Active long-term support (LTS) version of link:https://nodejs.org/en/about/releases/[Node] (`node`) .
 . Install link:https://github.com/nvm-sh/nvm[Node Version Manager] (`nvm`).
 . After you install `node` and `nvm`, run the following commands from your local  `app-services-guides` repository's top-level directory (for example, `Users/myname/mylocalGitRepos/app-services-guides/`):

--- a/docs/registry/access-mgmt-registry/README.adoc
+++ b/docs/registry/access-mgmt-registry/README.adoc
@@ -218,7 +218,6 @@ The role is also added to the list of selected roles on the *Roles* tab.
 * {base-url}{getting-started-url-registry}[_Getting started with {product-long-registry}_^]
 * {base-url}{getting-started-rhoas-cli-url-registry}[_Getting started with the rhoas CLI for {product-long-registry}_^]
 * {base-url-cli}{command-ref-url-cli}[_CLI command reference (rhoas)_^]
-* https://www.apicur.io/registry/docs/apicurio-registry/2.1.x/assets-attachments/registry-rest-api.htm[_Apicurio Registry REST API documentation_^]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
Remove hard-coded URL for old version of Apicurio REST API. Adds no value in this context anyway.  