### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/modular-docs-check.yml
+++ b/.github/workflows/modular-docs-check.yml
@@ -33,7 +33,7 @@ jobs:
         java-version: 15
         distribution: 'adopt' # See 'Supported distributions' for available options
     - name: Use Ruby 2.6
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d3c9825d67b0d8720afdfdde5af56c79fdb38d16 #v1
       with:
         ruby-version: '2.6'
 

--- a/.github/workflows/modular-docs-publish.yml
+++ b/.github/workflows/modular-docs-publish.yml
@@ -40,7 +40,7 @@ jobs:
           java-version: 15
           distribution: 'adopt' # See 'Supported distributions' for available options
       - name: Use Ruby 2.6
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d3c9825d67b0d8720afdfdde5af56c79fdb38d16 #v1
         with:
           ruby-version: '2.6'
 
@@ -54,7 +54,7 @@ jobs:
         env:
           DOCS_PRODUCT_NAME: ${{matrix.product}}
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@0f24da7de3e7e135102609a4c9633b025be8411b #4.1.5
         env:
           DEPLOY_BRANCH: ${{matrix.branch}}
         with:


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
