### PR TITLE
DRAFT: Removal of the RHODA QSG

### DIFF
--- a/docs/database-access/accessing-the-database-access-menu-for-configuring-and-monitoring/quickstart.yml
+++ b/docs/database-access/accessing-the-database-access-menu-for-configuring-and-monitoring/quickstart.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     categories: "Database management"
     order: 2
-    draft: false
+    draft: true
   labels:
     service-category/data-services: "true"
     product/rhoda: "true"

--- a/docs/database-access/accessing-the-developer-workspace-and-adding-a-database-instance/quickstart.yml
+++ b/docs/database-access/accessing-the-developer-workspace-and-adding-a-database-instance/quickstart.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     categories: "Database management"
     order: 3
-    draft: false
+    draft: true
   labels:
     service-category/data-services: "true"
     product/rhoda: "true"

--- a/docs/database-access/connecting-an-application-to-a-database-instance-using-the-topology-view/quickstart.yml
+++ b/docs/database-access/connecting-an-application-to-a-database-instance-using-the-topology-view/quickstart.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     categories: "Database management"
     order: 4
-    draft: false
+    draft: true
   labels:
     service-category/data-services: "true"
     product/rhoda: "true"

--- a/docs/database-access/installing-the-red-hat-openshift-database-access-add-on/quickstart.yml
+++ b/docs/database-access/installing-the-red-hat-openshift-database-access-add-on/quickstart.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     categories: "Database management"
     order: 1
-    draft: false
+    draft: true
   labels:
     service-category/data-services: "true"
     product/rhoda: "true"


### PR DESCRIPTION
Red Hat OpenShift Database Access service has been decommissioned, and moved to the [community](https://github.com/RHEcosystemAppEng/dbaas-operator).

Fixes: [DBAAS-1233](https://issues.redhat.com/browse/DBAAS-1233)